### PR TITLE
Add data auditing properties to all entities

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilityMapSummaryDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityMapSummaryDto.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FMS.Domain.Dto
 {
@@ -39,10 +40,12 @@ namespace FMS.Domain.Dto
 
         [Display(Name = "Latitude")]
         [DisplayFormat(DataFormatString = "{0:F6}")]
+        [Column(TypeName="decimal(8, 6)")]
         public decimal Latitude { get; set; }
 
         [Display(Name = "Longitude")]
         [DisplayFormat(DataFormatString = "{0:F6}")]
+        [Column(TypeName="decimal(9, 6)")]
         public decimal Longitude { get; set; }
 
         [Display(Name = "Distance")]

--- a/FMS.Domain/Entities/County.cs
+++ b/FMS.Domain/Entities/County.cs
@@ -2,7 +2,6 @@
 {
     public class County
     {
-        // This list will not change, so no need for "BaseActiveModel"
         public int Id { get; set; }
         public string Name { get; set; }
     }

--- a/FMS.Infrastructure/Contexts/FmsDbContext.cs
+++ b/FMS.Infrastructure/Contexts/FmsDbContext.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using System;
+// ReSharper disable UnusedAutoPropertyAccessor.Global
 
 namespace FMS.Infrastructure.Contexts
 {
@@ -13,9 +14,9 @@ namespace FMS.Infrastructure.Contexts
     {
         public FmsDbContext(DbContextOptions<FmsDbContext> options) : base(options) { }
 
+        // App entities
         public DbSet<BudgetCode> BudgetCodes { get; set; }
         public DbSet<ComplianceOfficer> ComplianceOfficers { get; set; }
-        public DbSet<County> Counties { get; set; }
         public DbSet<Facility> Facilities { get; set; }
         public DbSet<FacilityStatus> FacilityStatuses { get; set; }
         public DbSet<FacilityType> FacilityTypes { get; set; }
@@ -24,8 +25,15 @@ namespace FMS.Infrastructure.Contexts
         public DbSet<OrganizationalUnit> OrganizationalUnits { get; set; }
         public DbSet<RetentionRecord> RetentionRecords { get; set; }
         public DbSet<CabinetFile> CabinetFileJoin { get; set; }
-        // FacilityList only needed for retrieving results from [dbo].[getNearbyFacilities] stored procedure
-        // This should not be needed in .NET Core 5
+
+        // The "Counties" entity is only used to add a County table and data to the database for 
+        // database-side use. Counties are stored in memory and never accessed from the database,
+        // but other entities store County Id as a foreign key.
+        // ReSharper disable once UnusedMember.Global
+        public DbSet<County> Counties { get; set; }
+
+        // The "FacilityList" entity is only used for retrieving results from the [dbo].[getNearbyFacilities]
+        // stored procedure. (This should not be needed in .NET Core 5.)
         public DbSet<FacilityMapSummaryDto> FacilityList { get; set; }
 
         protected override void OnModelCreating(ModelBuilder builder)
@@ -52,7 +60,5 @@ namespace FMS.Infrastructure.Contexts
             // Data
             builder.Entity<County>().HasData(Data.Counties);
         }
-
-        //protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder.EnableSensitiveDataLogging();
     }
 }

--- a/FMS.Infrastructure/DbScripts/GetNearbyFacilities.cs
+++ b/FMS.Infrastructure/DbScripts/GetNearbyFacilities.cs
@@ -1,17 +1,17 @@
 ﻿using FMS.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 
-namespace FMS.Infrastructure.Procs
+namespace FMS.Infrastructure.DbScripts
 {
     public static class StoredProcedures
     {
         public static void CreateStoredProcedures(this FmsDbContext context)
         {
-            context.Database.ExecuteSqlRaw(GetNearbyFacilities);
+            context.Database.ExecuteSqlRaw(CreateSpGetNearbyFacilities);
         }
 
-        private const string GetNearbyFacilities = @"
-CREATE PROCEDURE [dbo].[getNearbyFacilities] 
+        public const string CreateSpGetNearbyFacilities = @"
+CREATE OR ALTER PROCEDURE [dbo].[getNearbyFacilities] 
     @active bit = null,
     @Lat float = NULL,
     @Lng float = NULL,
@@ -47,7 +47,7 @@ BEGIN
     WHERE T.distance <= @radius
     ORDER BY distance ASC;
 
-END;
+END
 ";
     }
 }

--- a/FMS.Infrastructure/Migrations/20201104163631_UpdateStoredProcedure.Designer.cs
+++ b/FMS.Infrastructure/Migrations/20201104163631_UpdateStoredProcedure.Designer.cs
@@ -4,14 +4,16 @@ using FMS.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FMS.Infrastructure.Migrations
 {
     [DbContext(typeof(FmsDbContext))]
-    partial class FmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201104163631_UpdateStoredProcedure")]
+    partial class UpdateStoredProcedure
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FMS.Infrastructure/Migrations/20201104163631_UpdateStoredProcedure.cs
+++ b/FMS.Infrastructure/Migrations/20201104163631_UpdateStoredProcedure.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FMS.Infrastructure.Migrations
+{
+    public partial class UpdateStoredProcedure : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FileId",
+                table: "FacilityList");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Longitude",
+                table: "FacilityList",
+                type: "decimal(9, 6)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Latitude",
+                table: "FacilityList",
+                type: "decimal(8, 6)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(18,2)");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Longitude",
+                table: "FacilityList",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(9, 6)");
+
+            migrationBuilder.AlterColumn<decimal>(
+                name: "Latitude",
+                table: "FacilityList",
+                type: "decimal(18,2)",
+                nullable: false,
+                oldClrType: typeof(decimal),
+                oldType: "decimal(8, 6)");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "FileId",
+                table: "FacilityList",
+                type: "uniqueidentifier",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+        }
+    }
+}

--- a/FMS.Infrastructure/Migrations/20201104165409_AddAuditingProperties.Designer.cs
+++ b/FMS.Infrastructure/Migrations/20201104165409_AddAuditingProperties.Designer.cs
@@ -4,14 +4,16 @@ using FMS.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace FMS.Infrastructure.Migrations
 {
     [DbContext(typeof(FmsDbContext))]
-    partial class FmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20201104165409_AddAuditingProperties")]
+    partial class AddAuditingProperties
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FMS.Infrastructure/Migrations/20201104165409_AddAuditingProperties.cs
+++ b/FMS.Infrastructure/Migrations/20201104165409_AddAuditingProperties.cs
@@ -1,0 +1,698 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace FMS.Infrastructure.Migrations
+{
+    public partial class AddAuditingProperties : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "RetentionRecords",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "RetentionRecords",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "RetentionRecords",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "RetentionRecords",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "OrganizationalUnits",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "OrganizationalUnits",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "OrganizationalUnits",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "OrganizationalUnits",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "Files",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "Files",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "Files",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "Files",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "FacilityTypes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "FacilityTypes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "FacilityTypes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "FacilityTypes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "FacilityStatuses",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "FacilityStatuses",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "FacilityStatuses",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "FacilityStatuses",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "FacilityList",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "FacilityList",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "FacilityList",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "FacilityList",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "Facilities",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "Facilities",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "Facilities",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "Facilities",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "Counties",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "Counties",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "Counties",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "Counties",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "ComplianceOfficers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "ComplianceOfficers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "ComplianceOfficers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "ComplianceOfficers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "Cabinets",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "Cabinets",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "Cabinets",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "Cabinets",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "CabinetFileJoin",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "CabinetFileJoin",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "CabinetFileJoin",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "CabinetFileJoin",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "BudgetCodes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "BudgetCodes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "BudgetCodes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "BudgetCodes",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppUserTokens",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppUserTokens",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppUserTokens",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppUserTokens",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppUsers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppUsers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppUsers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppUsers",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppUserRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppUserRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppUserRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppUserRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppUserLogins",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppUserLogins",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppUserLogins",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppUserLogins",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppUserClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppUserClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppUserClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppUserClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppRoles",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "InsertDateTime",
+                table: "AppRoleClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InsertUser",
+                table: "AppRoleClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdateDateTime",
+                table: "AppRoleClaims",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdateUser",
+                table: "AppRoleClaims",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "RetentionRecords");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "RetentionRecords");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "RetentionRecords");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "RetentionRecords");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "OrganizationalUnits");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "OrganizationalUnits");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "OrganizationalUnits");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "OrganizationalUnits");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "Files");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "FacilityTypes");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "FacilityTypes");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "FacilityTypes");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "FacilityTypes");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "FacilityStatuses");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "FacilityStatuses");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "FacilityStatuses");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "FacilityStatuses");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "FacilityList");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "FacilityList");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "FacilityList");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "FacilityList");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "Facilities");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "Facilities");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "Facilities");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "Facilities");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "Counties");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "Counties");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "Counties");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "Counties");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "ComplianceOfficers");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "ComplianceOfficers");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "ComplianceOfficers");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "ComplianceOfficers");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "Cabinets");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "Cabinets");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "Cabinets");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "Cabinets");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "CabinetFileJoin");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "CabinetFileJoin");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "CabinetFileJoin");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "CabinetFileJoin");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "BudgetCodes");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "BudgetCodes");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "BudgetCodes");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "BudgetCodes");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppUserTokens");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppUserTokens");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppUserTokens");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppUserTokens");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppUsers");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppUsers");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppUsers");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppUsers");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppUserRoles");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppUserRoles");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppUserRoles");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppUserRoles");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppUserLogins");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppUserLogins");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppUserLogins");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppUserLogins");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppUserClaims");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppUserClaims");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppUserClaims");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppUserClaims");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppRoles");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppRoles");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppRoles");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppRoles");
+
+            migrationBuilder.DropColumn(
+                name: "InsertDateTime",
+                table: "AppRoleClaims");
+
+            migrationBuilder.DropColumn(
+                name: "InsertUser",
+                table: "AppRoleClaims");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateDateTime",
+                table: "AppRoleClaims");
+
+            migrationBuilder.DropColumn(
+                name: "UpdateUser",
+                table: "AppRoleClaims");
+        }
+    }
+}

--- a/FMS/Services/MigratorHostedService.cs
+++ b/FMS/Services/MigratorHostedService.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using FMS.Domain.Entities.Users;
 using FMS.Infrastructure.Contexts;
-using FMS.Infrastructure.Procs;
+using FMS.Infrastructure.DbScripts;
 using FMS.Infrastructure.SeedData;
 using FMS.Infrastructure.SeedData.TestData;
 using Microsoft.AspNetCore.Hosting;

--- a/tests/TestHelpers/RepositoryHelper.cs
+++ b/tests/TestHelpers/RepositoryHelper.cs
@@ -14,7 +14,7 @@ namespace TestHelpers
 
         public RepositoryHelper()
         {
-            var context = new FmsDbContext(_options);
+            var context = new FmsDbContext(_options, default);
 
             context.Database.EnsureCreated();
             context.SeedData();
@@ -25,9 +25,9 @@ namespace TestHelpers
         }
 
         public FacilityRepository GetFacilityRepository() =>
-            new FacilityRepository(new FmsDbContext(_options), GetFileRepository());
+            new FacilityRepository(new FmsDbContext(_options, default), GetFileRepository());
 
         public FileRepository GetFileRepository() =>
-            new FileRepository(new FmsDbContext(_options));
+            new FileRepository(new FmsDbContext(_options, default));
     }
 }

--- a/tests/TestHelpers/SimpleRepository/SimpleRepositoryHelper.cs
+++ b/tests/TestHelpers/SimpleRepository/SimpleRepositoryHelper.cs
@@ -12,7 +12,7 @@ namespace TestHelpers.SimpleRepository
 
         public SimpleRepositoryHelper()
         {
-            var context = new FmsDbContext(_options);
+            var context = new FmsDbContext(_options, default);
             context.Database.EnsureCreated();
             context.Files.AddRange(SimpleRepositoryData.Files);
             context.Facilities.AddRange(SimpleRepositoryData.Facilities);
@@ -23,15 +23,15 @@ namespace TestHelpers.SimpleRepository
         }
 
         public IFacilityRepository GetFacilityRepository() =>
-            new FacilityRepository(new FmsDbContext(_options), GetFileRepository());
+            new FacilityRepository(new FmsDbContext(_options, default), GetFileRepository());
 
         public IFileRepository GetFileRepository() =>
-            new FileRepository(new FmsDbContext(_options));
+            new FileRepository(new FmsDbContext(_options, default));
 
         public IItemsListRepository GetItemsListRepository() =>
-            new ItemsListRepository(new FmsDbContext(_options));
+            new ItemsListRepository(new FmsDbContext(_options, default));
 
         public ICabinetRepository GetCabinetRepository() =>
-            new CabinetRepository(new FmsDbContext(_options));
+            new CabinetRepository(new FmsDbContext(_options, default));
     }
 }


### PR DESCRIPTION
The properties are added in the DbContext and the values are set by overriding the SaveChanges methods.

closes #149 