### PR TITLE
Don't dispose the DB connection when calling stored procedures

### DIFF
--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -159,7 +159,7 @@ namespace FMS.Infrastructure.Repositories
 
         public async Task<IReadOnlyList<FacilityMapSummaryDto>> GetFacilityListAsync(FacilityMapSpec spec)
         {
-            await using var conn = _context.Database.GetDbConnection();
+            var conn = _context.Database.GetDbConnection();
             return (await conn.QueryAsync<FacilityMapSummaryDto>("dbo.getNearbyFacilities",
                 new {Active = !spec.ShowDeleted, spec.Latitude, spec.Longitude, spec.Radius},
                 commandType: CommandType.StoredProcedure)).ToList();


### PR DESCRIPTION
When I switched to Dapper for calling the stored procedure, I used the language provided for getting the DB connection:

```csharp
await using var conn = _context.Database.GetDbConnection();
return (await conn.QueryAsync<FacilityMapSummaryDto>("dbo.getNearbyFacilities",
    new {Active = !spec.ShowDeleted, spec.Latitude, spec.Longitude, spec.Radius},
    commandType: CommandType.StoredProcedure)).ToList();
```

The mistake is that the `using` block causes the DbConnection to get disposed after calling the SP.

This works okay on the location search page, because the `getNearbyFacilities` stored procedure is the last database call before returning the page (and disposing the DbContext). But on the Add Facility page, if nearby facilities are found, then a confirmation page is shown. When the page attempts to populate the SelectLists, it fails because the DbConnection has already been disposed.

Removing the using block fixes the issue. The [EF team has confirmed](https://github.com/dotnet/efcore/issues/7810#issuecomment-285127729) that the DbConnection will be disposed by Entity Framework when the DbContext is disposed. (The repository is scoped, so the context is disposed at the end of the request.)

ref #179