### PR TITLE
Enable searching users by Role

### DIFF
--- a/FMS.Domain/Services/IUserService.cs
+++ b/FMS.Domain/Services/IUserService.cs
@@ -1,8 +1,7 @@
-﻿using FMS.Domain.Entities.Users;
-using Microsoft.AspNetCore.Identity;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Identity;
 
 namespace FMS.Domain.Services
 {
@@ -12,16 +11,15 @@ namespace FMS.Domain.Services
     public interface IUserService
     {
         // Current user
-        public Task<ApplicationUser> GetCurrentUserAsync();
+        public Task<UserView> GetCurrentUserAsync();
         public Task<IList<string>> GetCurrentUserRolesAsync();
 
         // Any user        
-        public Task<ApplicationUser> GetUserByIdAsync(Guid id);
+        public Task<UserView> GetUserByIdAsync(Guid id);
         public Task<IList<string>> GetUserRolesAsync(Guid id);
         public Task<IdentityResult> UpdateUserRolesAsync(Guid id, Dictionary<string, bool> roleSettings);
 
         // User search
-        public Task<List<ApplicationUser>> GetUsersAsync(string nameFilter, string emailFilter);
-        public Task<ApplicationUser> GetUserAsync(string email);
+        public Task<List<UserView>> GetUsersAsync(string nameFilter, string emailFilter, string role);
     }
 }

--- a/FMS.Domain/Services/UserView.cs
+++ b/FMS.Domain/Services/UserView.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using FMS.Domain.Entities.Users;
+
+namespace FMS.Domain.Services
+{
+    public class UserView
+    {
+        public UserView(ApplicationUser user) =>
+            (Id, DisplayName, Email) = (user.Id, user.DisplayName, user.Email);
+
+        public Guid Id { get; }
+        public string DisplayName { get; }
+        public string Email { get; }
+    }
+}

--- a/FMS/Pages/Account/Index.cshtml
+++ b/FMS/Pages/Account/Index.cshtml
@@ -8,8 +8,8 @@
 <h1>@ViewData["Title"]</h1>
 <hr />
 
-<h2>@Model.DisplayName</h2>
-<p>@Model.Email</p>
+<h2>@Model.CurrentUser.DisplayName</h2>
+<p>@Model.CurrentUser.Email</p>
 
 @if (Model.Roles != null && Model.Roles.Count > 0)
 {

--- a/FMS/Pages/Account/Index.cshtml.cs
+++ b/FMS/Pages/Account/Index.cshtml.cs
@@ -1,9 +1,9 @@
-using FMS.Domain.Services;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using FMS.Domain.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FMS.Pages.Account
 {
@@ -12,19 +12,14 @@ namespace FMS.Pages.Account
         private readonly IUserService _userService;
         public IndexModel(IUserService userService) => _userService = userService;
 
-        public string DisplayName { get; private set; }
-        public string Email { get; private set; }
+        public UserView CurrentUser { get; private set; }
         public IList<string> Roles { get; private set; }
 
         public async Task<IActionResult> OnGetAsync()
         {
-            var currentUser = await _userService.GetCurrentUserAsync()
+            CurrentUser = await _userService.GetCurrentUserAsync()
                 ?? throw new Exception("Current user not found");
-
-            DisplayName = currentUser.DisplayName;
-            Email = currentUser.Email;
             Roles = await _userService.GetCurrentUserRolesAsync();
-
             return Page();
         }
     }

--- a/FMS/Pages/Shared/_PaginationNav.cshtml
+++ b/FMS/Pages/Shared/_PaginationNav.cshtml
@@ -32,11 +32,12 @@
                 i <= Math.Min(Model.paging.PageNumber + 2, Model.paging.TotalPages);
                 i++)
             {
-                @if (i == Model.paging.PageNumber)
+                var index = i;
+                @if (index == Model.paging.PageNumber)
                 {
                     <li class="page-item active" aria-current="page">
                         <span class="page-link">
-                            @i.ToString() <span class="sr-only">(current)</span>
+                            @index.ToString() <span class="sr-only">(current)</span>
                         </span>
                     </li>
                 }
@@ -45,8 +46,8 @@
                     <li class="page-item">
                         <a class="page-link" asp-fragment="SearchResults"
                            asp-all-route-data="@Model.routeValues" asp-route-handler="search"
-                           asp-route-p="@i">
-                            @i.ToString()
+                           asp-route-p="@index">
+                            @index.ToString()
                         </a>
                     </li>
                 }

--- a/FMS/Pages/Users/Index.cshtml
+++ b/FMS/Pages/Users/Index.cshtml
@@ -23,6 +23,12 @@
                 <label asp-for="Email"></label>
                 <input asp-for="Email" class="form-control" />
             </div>
+            <div class="form-group col">
+                <label asp-for="Role"></label>
+                <select asp-for="Role" asp-items="Model.RoleItems" class="custom-select">
+                    <option value="">(any)</option>
+                </select>
+            </div>
         </div>
         <input type="hidden" name="handler" value="search" />
         <button id="SearchButton" type="submit" class="btn btn-primary col-sm-3 mb-3 mb-sm-0">Search</button>
@@ -34,7 +40,7 @@
 {
     <a id="SearchResults"></a>
 
-    @if (Model.SearchResults != null && Model.SearchResults.Count > 0)
+    @if (Model.SearchResults is {Count: > 0 })
     {
         <table class="table table-borderless">
             <thead class="thead-light">
@@ -48,7 +54,7 @@
             @foreach (var item in Model.SearchResults)
             {
                 <tr>
-                    <td>@Html.DisplayFor(m => item.Name)</td>
+                    <td>@Html.DisplayFor(m => item.DisplayName)</td>
                     <td>@Html.DisplayFor(m => item.Email)</td>
                     <td class="text-center">
                         <a asp-page="./Details" asp-route-id="@item.Id" class="btn btn-outline-info btn-sm">View</a>

--- a/FMS/Pages/Users/Index.cshtml.cs
+++ b/FMS/Pages/Users/Index.cshtml.cs
@@ -1,58 +1,46 @@
-﻿using FMS.Domain.Services;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace FMS.Pages.Users
 {
     public class IndexModel : PageModel
     {
-        private readonly IUserService _userService;
-        public IndexModel(IUserService userService) => _userService = userService;
-
-        public string Name { get; set; }
+        public string Name { get; init; }
 
         [EmailAddress]
-        public string Email { get; set; }
+        public string Email { get; init; }
 
-        public bool ShowResults { get; set; }
-        public List<UserSearchResult> SearchResults { get; set; }
+        public string Role { get; init; }
+
+        public IEnumerable<SelectListItem> RoleItems { get; } =
+            UserRoles.AllRoles.Select(d => new SelectListItem(UserRoles.DisplayName(d), d));
+
+        public bool ShowResults { get; private set; }
+        public List<UserView> SearchResults { get; private set; }
 
         public void OnGet()
         {
             // Method intentionally left empty.
         }
 
-        public async Task<IActionResult> OnGetSearchAsync(string name, string email)
+        public async Task<IActionResult> OnGetSearchAsync([FromServices] IUserService userService,
+            string name, string email, string role)
         {
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
-            var users = await _userService.GetUsersAsync(name, email);
-
+            SearchResults = await userService.GetUsersAsync(name, email, role);
             ShowResults = true;
-            SearchResults = users.Select(e =>
-                new UserSearchResult()
-                {
-                    Email = e.Email,
-                    Name = e.SortableFullName,
-                    Id = e.Id
-                }).ToList();
-
             return Page();
-        }
-
-        public class UserSearchResult
-        {
-            public Guid Id { get; set; }
-            public string Name { get; set; }
-            public string Email { get; set; }
         }
     }
 }

--- a/tests/FMS.App.Tests/Account/AccountIndexTests.cs
+++ b/tests/FMS.App.Tests/Account/AccountIndexTests.cs
@@ -15,25 +15,25 @@ namespace FMS.App.Tests.Account
         [Fact]
         public async Task OnGet_PopulatesThePageModel()
         {
-            var user = new ApplicationUser()
+            var userView = new UserView(new ApplicationUser
             {
                 Id = Guid.Empty,
                 Email = "example.one@example.com",
                 GivenName = "Sample",
                 FamilyName = "User"
-            };
+            });
 
             var mockUserService = new Mock<IUserService>();
             mockUserService.Setup(l => l.GetCurrentUserAsync())
-                .ReturnsAsync(user)
+                .ReturnsAsync(userView)
                 .Verifiable();
             var pageModel = new IndexModel(mockUserService.Object);
 
             var result = await pageModel.OnGetAsync().ConfigureAwait(false);
 
             result.Should().BeOfType<PageResult>();
-            pageModel.Email.Should().Be(user.Email);
-            pageModel.DisplayName.Should().Be(user.DisplayName);
+            pageModel.CurrentUser.Email.Should().Be(userView.Email);
+            pageModel.CurrentUser.DisplayName.Should().Be(userView.DisplayName);
         }
     }
 }

--- a/tests/FMS.App.Tests/Users/UserDetailsTests.cs
+++ b/tests/FMS.App.Tests/Users/UserDetailsTests.cs
@@ -16,7 +16,7 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_PopulatesThePageModel()
         {
-            var user = UserTestData.ApplicationUsers[0];
+            var user = new UserView(UserTestData.ApplicationUsers[0]);
 
             var mockUserService = new Mock<IUserService>();
             mockUserService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))

--- a/tests/FMS.App.Tests/Users/UserEditTests.cs
+++ b/tests/FMS.App.Tests/Users/UserEditTests.cs
@@ -19,7 +19,7 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_PopulatesThePageModel()
         {
-            var user = UserTestData.ApplicationUsers[0];
+            var user = new UserView(UserTestData.ApplicationUsers[0]);
 
             var mockRepo = new Mock<IUserService>();
             mockRepo.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
@@ -44,7 +44,7 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_WithRoles_PopulatesThePageModel()
         {
-            var user = UserTestData.ApplicationUsers[0];
+            var user = new UserView(UserTestData.ApplicationUsers[0]);
             var roles = new List<string>()
             {
                 UserRoles.FileCreator,
@@ -90,7 +90,7 @@ namespace FMS.App.Tests.Users
         {
             var mockRepo = new Mock<IUserService>();
             mockRepo.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((ApplicationUser) null);
+                .ReturnsAsync((UserView)null);
             var pageModel = new EditModel(mockRepo.Object);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
@@ -115,8 +115,8 @@ namespace FMS.App.Tests.Users
 
             pageModel.ModelState.IsValid.ShouldBeTrue();
             result.Should().BeOfType<RedirectToPageResult>();
-            ((RedirectToPageResult) result).PageName.Should().Be("./Details");
-            ((RedirectToPageResult) result).RouteValues["id"].Should().Be(Guid.Empty);
+            ((RedirectToPageResult)result).PageName.Should().Be("./Details");
+            ((RedirectToPageResult)result).RouteValues["id"].Should().Be(Guid.Empty);
         }
 
         [Fact]
@@ -136,9 +136,9 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnPost_UpdateRolesFails_ReturnsPageWithInvalidModelState()
         {
-            var user = UserTestData.ApplicationUsers[0];
+            var user = new UserView(UserTestData.ApplicationUsers[0]);
             var identityResult = IdentityResult.Failed(
-                new IdentityError() {Code = "CODE", Description = "DESCRIPTION"});
+                new IdentityError() { Code = "CODE", Description = "DESCRIPTION" });
 
             var mockRepo = new Mock<IUserService>();
             mockRepo.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))

--- a/tests/FMS.App.Tests/Users/UserSearchTests.cs
+++ b/tests/FMS.App.Tests/Users/UserSearchTests.cs
@@ -7,29 +7,28 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Moq;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
-using static FMS.Pages.Users.IndexModel;
 
 namespace FMS.App.Tests.Users
 {
     public class UserSearchTests
     {
         [Theory]
-        [InlineData(null, null)]
-        [InlineData("a", "b")]
-        public async Task OnSearch_IfValidModel_ReturnPage(string name, string email)
+        [InlineData(null, null, null)]
+        [InlineData("a", "b", "c")]
+        public async Task OnSearch_IfValidModel_ReturnPage(string name, string email, string role)
         {
-            var users = UserTestData.ApplicationUsers;
-            var searchResults = users
-                .Select(e => new UserSearchResult() {Email = e.Email, Name = e.SortableFullName, Id = e.Id})
+            var searchResults = UserTestData.ApplicationUsers
+                .Select(e => new UserView(e))
                 .ToList();
 
             var mockUserService = new Mock<IUserService>();
-            mockUserService.Setup(l => l.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(users)
+            mockUserService.Setup(l => l.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(searchResults)
                 .Verifiable();
-            var pageModel = new IndexModel(mockUserService.Object);
+            var pageModel = new IndexModel();
 
-            var result = await pageModel.OnGetSearchAsync(name, email).ConfigureAwait(false);
+            var result = await pageModel.OnGetSearchAsync(mockUserService.Object, name, email, role)
+                .ConfigureAwait(false);
 
             result.Should().BeOfType<PageResult>();
             pageModel.ModelState.IsValid.ShouldBeTrue();
@@ -40,10 +39,11 @@ namespace FMS.App.Tests.Users
         public async Task OnSearch_IfInvalidModel_ReturnPageWithInvalidModelState()
         {
             var mockUserService = new Mock<IUserService>();
-            var pageModel = new IndexModel(mockUserService.Object);
+            var pageModel = new IndexModel();
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
-            var result = await pageModel.OnGetSearchAsync(null, null).ConfigureAwait(false);
+            var result = await pageModel.OnGetSearchAsync(mockUserService.Object, null, null, null)
+                .ConfigureAwait(false);
 
             result.Should().BeOfType<PageResult>();
             pageModel.ModelState.IsValid.ShouldBeFalse();


### PR DESCRIPTION
I added the ability to search FMS users by role. 

This required changing the `GetUsersAsync` method in the `UserService` to search by role name if supplied. I also refactored other methods in `IUserService` to only return a minimal `UserView` instead of the full `ApplicationUser` object.

closes #184