### PR TITLE
Consolidate build files in artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@ appsettings\.Staging\.json
 appsettings\.Development\.json
 appsettings\.Local\.json
 
-# Content folders
-_GeneratedFiles/
-
 # SonarLint Rider plugin
 .idea/.idea.FMS/.idea/sonarlint-state.xml
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,8 @@
 <Project>
+    <PropertyGroup>
+        <BaseOutputPath>$(MSBuildThisFileDirectory)artifacts\$(MSBuildProjectName)\bin\</BaseOutputPath>
+        <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)artifacts\$(MSBuildProjectName)\obj\</BaseIntermediateOutputPath>
+    </PropertyGroup>
 
     <PropertyGroup>
         <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory).sonarlint\gaepdit_fmscsharp.ruleset</CodeAnalysisRuleSet>
@@ -7,5 +11,4 @@
     <ItemGroup>
         <AdditionalFiles Include="$(MSBuildThisFileDirectory).sonarlint\gaepdit_fms\CSharp\SonarLint.xml" Link="SonarLint.xml" />
     </ItemGroup>
-
 </Project>

--- a/FMS/appsettings.json
+++ b/FMS/appsettings.json
@@ -10,7 +10,7 @@
     "ClientSecret": "[Enter a Client Secret from the Azure portal]"
   },
   "SeedAdminUsers": [],
-  "PersistedFilesBasePath": "../_GeneratedFiles",
+  "PersistedFilesBasePath": "../artifacts/_GeneratedFiles",
   "GoogleMapSettings": {
     "ApiKey": ""
   },


### PR DESCRIPTION
Instead of having `bin` and `obj` folders created within every project folder, this update causes all build directories to be grouped under a single `artifacts` directory. This is mostly aesthetic, but it does make it easier to manually delete all build directories if needed.