### PR TITLE
Fix for Facility Edit page showing (deleted) on save, and to allow Duplicate Facility numbers to save

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilityEditDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityEditDto.cs
@@ -37,7 +37,7 @@ namespace FMS.Domain.Dto
         public string Name { get; set; }
 
         [Display(Name = "Active Site")]
-        public bool Active { get; }
+        public bool Active { get; set; }
 
         [Required]
         [Display(Name = "County")]

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -238,11 +238,6 @@ namespace FMS.Infrastructure.Repositories
                 throw new ArgumentException("Facility ID not found.", nameof(id));
             }
 
-            if (await FacilityNumberExists(facilityUpdates.FacilityNumber, id))
-            {
-                throw new ArgumentException($"Facility Number '{facilityUpdates.FacilityNumber}' already exists.");
-            }
-
             if (string.IsNullOrWhiteSpace(facilityUpdates.FileLabel))
             {
                 // Generate new File if File Label is empty

--- a/FMS/Pages/Facilities/Edit.cshtml
+++ b/FMS/Pages/Facilities/Edit.cshtml
@@ -22,6 +22,7 @@
 
 <div class="container bg-light py-3">
     <form method="post">
+        <input type="hidden" asp-for="Facility.Active" />
         <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
         <div class="form-row">
             <div class="form-group col-md">

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -91,12 +91,6 @@ namespace FMS.Pages.Facilities
                 }
             }
 
-            // If editing facility number, make sure the new number doesn't already exist before trying to save.
-            if (await _repository.FacilityNumberExists(Facility.FacilityNumber, Id))
-            {
-                ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists.");
-            }
-
             if (!ModelState.IsValid)
             {
                 await PopulateSelectsAsync();

--- a/tests/FMS.Infrastructure.Tests/FacilityRepositoryTests.cs
+++ b/tests/FMS.Infrastructure.Tests/FacilityRepositoryTests.cs
@@ -690,26 +690,6 @@ namespace FMS.Infrastructure.Tests
                 .WithMessage($"File Label {newFileLabel} does not exist.");
         }
 
-        [Fact]
-        public async Task UpdateFacility_WithExistingNumber_ThrowsException()
-        {
-            var existingNumber = RepositoryData.Facilities()[1].FacilityNumber;
-
-            Func<Task> action = async () =>
-            {
-                using var repository = CreateRepositoryHelper().GetFacilityRepository();
-
-                var facilityId = RepositoryData.Facilities()[0].Id;
-                var facility = ResourceHelper.GetFacilityDetail(facilityId);
-                var updates = new FacilityEditDto(facility) {FacilityNumber = existingNumber};
-
-                await repository.UpdateFacilityAsync(facilityId, updates);
-            };
-
-            (await action.Should().ThrowAsync<ArgumentException>().ConfigureAwait(false))
-                .WithMessage($"Facility Number '{existingNumber}' already exists.");
-        }
-
         // GetNextSequenceForCounty
 
         [Fact]


### PR DESCRIPTION
This fixes Facility Edit.cshtml page from showing (deleted) after saving when page requirements are not met.
Also Fixes the inability to save a Facility with a duplicate Facility number to another Facility. 
Adding duplicate Facilities is still not allowed. However, due to the large number of historical data with duplicate Facility Numbers in the existing DB, Editing must be allowed to allow fixing of data. 

closes Issue #199