### PR TITLE
Check Facility Geocoordinates to make sure they are in Georgia

### DIFF
--- a/FMS/Helpers/GeoCoordHelper.cs
+++ b/FMS/Helpers/GeoCoordHelper.cs
@@ -2,14 +2,16 @@
 {
     public static class GeoCoordHelper
     {
-        public const decimal nullLatLong = 0.0m;
-        public const decimal upperLat = 35.0m;
-        public const decimal lowerLat = 30.36m;
-        public const decimal easternLong = -80.84m;
-        public const decimal westernLong = -85.61m;
+        private const decimal NULL_LAT_LONG = 0.0m;
+        private const decimal UPPER_LAT = 35.0m;
+        private const decimal LOWER_LAT = 30.36m;
+        private const decimal EASTERN_LONG = -80.84m;
+        private const decimal WESTERN_LONG = -85.61m;
 
-        public static bool InvalidLat(decimal Lat) => _ = Lat != nullLatLong && (Lat > upperLat || Lat < lowerLat);
+        public static bool InvalidLat(decimal lat) => _ = lat != NULL_LAT_LONG && (lat > UPPER_LAT || lat < LOWER_LAT);
 
-        public static bool InvalidLong(decimal Long) => _ = Long != nullLatLong && (Long > easternLong || Long < westernLong);
+        public static bool InvalidLong(decimal lng) => _ = lng != NULL_LAT_LONG && (lng > EASTERN_LONG || lng < WESTERN_LONG);
+
+        public static bool BothZeros(decimal lat, decimal lng) => _ = (lat == 0 && lng == 0) || (lat != 0 && lng != 0);
     }
 }

--- a/FMS/Helpers/GeoCoordHelper.cs
+++ b/FMS/Helpers/GeoCoordHelper.cs
@@ -2,16 +2,16 @@
 {
     public static class GeoCoordHelper
     {
-        private const decimal NULL_LAT_LONG = 0.0m;
-        private const decimal UPPER_LAT = 35.0m;
-        private const decimal LOWER_LAT = 30.36m;
-        private const decimal EASTERN_LONG = -80.84m;
-        private const decimal WESTERN_LONG = -85.61m;
+        private const decimal NullLatLong = 0.0m;
+        public const decimal UpperLat = 35.0m;
+        public const decimal LowerLat = 30.36m;
+        public const decimal EasternLong = -80.84m;
+        public const decimal WesternLong = -85.61m;
 
-        public static bool InvalidLat(decimal lat) => _ = lat != NULL_LAT_LONG && (lat > UPPER_LAT || lat < LOWER_LAT);
+        public static bool ValidLat(decimal lat) => lat is NullLatLong or <= UpperLat and >= LowerLat;
 
-        public static bool InvalidLong(decimal lng) => _ = lng != NULL_LAT_LONG && (lng > EASTERN_LONG || lng < WESTERN_LONG);
+        public static bool ValidLong(decimal lng) => lng is NullLatLong or <= EasternLong and >= WesternLong;
 
-        public static bool BothZeros(decimal lat, decimal lng) => _ = (lat == 0 && lng == 0) || (lat != 0 && lng != 0);
+        public static bool BothZeroOrBothNonzero(decimal lat, decimal lng) => (lat == 0 && lng == 0) || (lat != 0 && lng != 0);
     }
 }

--- a/FMS/Helpers/GeoCoordHelper.cs
+++ b/FMS/Helpers/GeoCoordHelper.cs
@@ -1,0 +1,15 @@
+﻿namespace FMS
+{
+    public static class GeoCoordHelper
+    {
+        public const decimal nullLatLong = 0.0m;
+        public const decimal upperLat = 35.0m;
+        public const decimal lowerLat = 30.36m;
+        public const decimal easternLong = -80.84m;
+        public const decimal westernLong = -85.61m;
+
+        public static bool InvalidLat(decimal Lat) => _ = Lat != nullLatLong && (Lat > upperLat || Lat < lowerLat);
+
+        public static bool InvalidLong(decimal Long) => _ = Long != nullLatLong && (Long > easternLong || Long < westernLong);
+    }
+}

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -63,20 +63,24 @@ namespace FMS.Pages.Facilities
             Facility.TrimAll();
 
             // If Latitude is 0.00 then Longitude must also be 0.00
-            if (Facility.Latitude != null && (!GeoCoordHelper.BothZeros((decimal)Facility.Latitude, (decimal)Facility.Longitude)))
+            if (!GeoCoordHelper.BothZeroOrBothNonzero(Facility.Latitude!.Value, Facility.Longitude!.Value))
             {
-                ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero(0) or both valid coordinates. ");
+                ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero (0) or both valid coordinates.");
             }
-
-            // If Latitude and/or Longitude fall outside State of Georgia, then alert user
-            if (Facility.Latitude != null && (GeoCoordHelper.InvalidLat((decimal)Facility.Latitude)))
+            else
             {
-                ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
-            }
+                // If Latitude and/or Longitude fall outside State of Georgia, then alert user
+                if (!GeoCoordHelper.ValidLat(Facility.Latitude!.Value))
+                {
+                    ModelState.AddModelError("Facility.Latitude", 
+                        $"Latitude entered is outside State of Georgia. Must be between {GeoCoordHelper.UpperLat} and {GeoCoordHelper.LowerLat} North Latitude or zero if unknown.");
+                }
 
-            if (Facility.Longitude != null && (GeoCoordHelper.InvalidLong((decimal)Facility.Longitude)))
-            {
-                ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
+                if (!GeoCoordHelper.ValidLong(Facility.Longitude!.Value))
+                {
+                    ModelState.AddModelError("Facility.Longitude",
+                        $"Longitude entered is outside State of Georgia. Must be between {GeoCoordHelper.EasternLong} and {GeoCoordHelper.WesternLong} West Longitude or zero if unknown.");
+                }
             }
 
             // If File Label is provided, make sure it exists

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -62,6 +62,12 @@ namespace FMS.Pages.Facilities
 
             Facility.TrimAll();
 
+            // If Latitude is 0.00 then Longitude must also be 0.00
+            if (!GeoCoordHelper.BothZeros((decimal)Facility.Latitude, (decimal)Facility.Longitude))
+            {
+                ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero(0) or both valid coordinates. ");
+            }
+
             // If Latitude and/or Longitude fall outside State of Georgia, then alert user
             if (GeoCoordHelper.InvalidLat((decimal)Facility.Latitude))
             {

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -63,18 +63,18 @@ namespace FMS.Pages.Facilities
             Facility.TrimAll();
 
             // If Latitude is 0.00 then Longitude must also be 0.00
-            if (!GeoCoordHelper.BothZeros((decimal)Facility.Latitude, (decimal)Facility.Longitude))
+            if (Facility.Latitude != null && (!GeoCoordHelper.BothZeros((decimal)Facility.Latitude, (decimal)Facility.Longitude)))
             {
                 ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero(0) or both valid coordinates. ");
             }
 
             // If Latitude and/or Longitude fall outside State of Georgia, then alert user
-            if (GeoCoordHelper.InvalidLat((decimal)Facility.Latitude))
+            if (Facility.Latitude != null && (GeoCoordHelper.InvalidLat((decimal)Facility.Latitude)))
             {
                 ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
             }
 
-            if (GeoCoordHelper.InvalidLong((decimal)Facility.Longitude))
+            if (Facility.Longitude != null && (GeoCoordHelper.InvalidLong((decimal)Facility.Longitude)))
             {
                 ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
             }

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -62,6 +62,22 @@ namespace FMS.Pages.Facilities
 
             Facility.TrimAll();
 
+            // If Latitude and/or Longitude fall outside State of Georgia, then alert user
+            decimal nullLatLong = 0.0m;
+            decimal upperLat = 35.0m;
+            decimal lowerLat = 30.36m;
+            if (Facility.Latitude != nullLatLong && (Facility.Latitude > upperLat || Facility.Latitude < lowerLat))
+            {
+                ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
+            }
+
+            decimal easternLong = -80.84m;
+            decimal westernLong = -85.61m;
+            if (Facility.Longitude != nullLatLong && (Facility.Longitude > easternLong || Facility.Longitude < westernLong))
+            {
+                ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
+            }
+
             // If File Label is provided, make sure it exists
             if (!string.IsNullOrWhiteSpace(Facility.FileLabel))
             {

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -63,17 +63,12 @@ namespace FMS.Pages.Facilities
             Facility.TrimAll();
 
             // If Latitude and/or Longitude fall outside State of Georgia, then alert user
-            decimal nullLatLong = 0.0m;
-            decimal upperLat = 35.0m;
-            decimal lowerLat = 30.36m;
-            if (Facility.Latitude != nullLatLong && (Facility.Latitude > upperLat || Facility.Latitude < lowerLat))
+            if (GeoCoordHelper.InvalidLat((decimal)Facility.Latitude))
             {
                 ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
             }
 
-            decimal easternLong = -80.84m;
-            decimal westernLong = -85.61m;
-            if (Facility.Longitude != nullLatLong && (Facility.Longitude > easternLong || Facility.Longitude < westernLong))
+            if (GeoCoordHelper.InvalidLong((decimal)Facility.Longitude))
             {
                 ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
             }

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -78,6 +78,22 @@ namespace FMS.Pages.Facilities
 
             Facility.TrimAll();
 
+            // If Latitude and/or Longitude fall outside State of Georgia, then alert user
+            decimal nullLatLong = 0.0m;
+            decimal upperLat = 35.0m;
+            decimal lowerLat = 30.36m;
+            if (Facility.Latitude != nullLatLong && (Facility.Latitude > upperLat || Facility.Latitude < lowerLat))
+            {
+                ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
+            }
+
+            decimal easternLong = -80.84m;
+            decimal westernLong = -85.61m;
+            if (Facility.Longitude != nullLatLong && (Facility.Longitude > easternLong || Facility.Longitude < westernLong))
+            {
+                ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
+            }
+
             // If new File Label is provided, make sure it exists
             if (!string.IsNullOrWhiteSpace(Facility.FileLabel))
             {

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -77,6 +77,12 @@ namespace FMS.Pages.Facilities
             }
 
             Facility.TrimAll();
+            
+            // If Latitude is 0.00 then Longitude must also be 0.00
+            if (!GeoCoordHelper.BothZeros(Facility.Latitude, Facility.Longitude))
+            {
+                ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero(0) or both valid coordinates. ");
+            }
 
             // If Latitude and/or Longitude fall outside State of Georgia, then alert user
             if (GeoCoordHelper.InvalidLat(Facility.Latitude))

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -79,20 +79,24 @@ namespace FMS.Pages.Facilities
             Facility.TrimAll();
             
             // If Latitude is 0.00 then Longitude must also be 0.00
-            if (!GeoCoordHelper.BothZeros(Facility.Latitude, Facility.Longitude))
+            if (!GeoCoordHelper.BothZeroOrBothNonzero(Facility.Latitude, Facility.Longitude))
             {
-                ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero(0) or both valid coordinates. ");
+                ModelState.AddModelError("Facility.Latitude", "Latitude and Longitude must both be zero (0) or both valid coordinates.");
             }
-
-            // If Latitude and/or Longitude fall outside State of Georgia, then alert user
-            if (GeoCoordHelper.InvalidLat(Facility.Latitude))
+            else
             {
-                ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
-            }
+                // If Latitude and/or Longitude fall outside State of Georgia, then alert user
+                if (!GeoCoordHelper.ValidLat(Facility.Latitude))
+                {
+                    ModelState.AddModelError("Facility.Latitude",
+                        $"Latitude entered is outside State of Georgia. Must be between {GeoCoordHelper.UpperLat} and {GeoCoordHelper.LowerLat} North Latitude or zero if unknown.");
+                }
 
-            if (GeoCoordHelper.InvalidLong(Facility.Longitude))
-            {
-                ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
+                if (!GeoCoordHelper.ValidLong(Facility.Longitude))
+                {
+                    ModelState.AddModelError("Facility.Longitude",
+                        $"Longitude entered is outside State of Georgia. Must be between {GeoCoordHelper.EasternLong} and {GeoCoordHelper.WesternLong} West Longitude or zero if unknown.");
+                }
             }
 
             // If new File Label is provided, make sure it exists

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -79,17 +79,12 @@ namespace FMS.Pages.Facilities
             Facility.TrimAll();
 
             // If Latitude and/or Longitude fall outside State of Georgia, then alert user
-            decimal nullLatLong = 0.0m;
-            decimal upperLat = 35.0m;
-            decimal lowerLat = 30.36m;
-            if (Facility.Latitude != nullLatLong && (Facility.Latitude > upperLat || Facility.Latitude < lowerLat))
+            if (GeoCoordHelper.InvalidLat(Facility.Latitude))
             {
                 ModelState.AddModelError("Facility.Latitude", "Latitude entered is outside State of Georgia. Must be between 30.36 and 35.0 North Latitude or zero if unknown.");
             }
 
-            decimal easternLong = -80.84m;
-            decimal westernLong = -85.61m;
-            if (Facility.Longitude != nullLatLong && (Facility.Longitude > easternLong || Facility.Longitude < westernLong))
+            if (GeoCoordHelper.InvalidLong(Facility.Longitude))
             {
                 ModelState.AddModelError("Facility.Longitude", "Longitude entered is outside State of Georgia. Must be between -80.84 and -85.61 West Longitude or zero if unknown.");
             }

--- a/tests/FMS.App.Tests/Facilities/FacilityAddTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityAddTests.cs
@@ -43,7 +43,7 @@ namespace FMS.App.Tests.Facilities
             var mockSelectListHelper = new Mock<ISelectListHelper>();
             var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object)
             {
-                Facility = new FacilityCreateDto {State = "Georgia"}
+                Facility = new FacilityCreateDto {State = "Georgia", Latitude = 0, Longitude = 0},
             };
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
@@ -75,7 +75,7 @@ namespace FMS.App.Tests.Facilities
             var mockSelectListHelper = new Mock<ISelectListHelper>();
             var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object)
             {
-                Facility = new FacilityCreateDto {State = "Georgia"}
+                Facility = new FacilityCreateDto {State = "Georgia", Latitude = 0, Longitude = 0},
             };
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);

--- a/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
+++ b/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using CsvHelper.Configuration;
+using FluentAssertions;
+using JetBrains.Annotations;
+using Xunit;
+
+namespace FMS.App.Tests.Helpers
+{
+    public class GeoCoordHelperTests
+    {
+        // Null values are filtered out by the form validation
+
+        [Theory]
+        [InlineData(0.00)]
+        [InlineData(32.456)]
+        public void InvalidLatIsFalse(decimal lat)
+        {
+            Assert.False(GeoCoordHelper.InvalidLat(lat));
+        }
+
+        [Theory]
+        [InlineData(37.23)]
+        [InlineData(38.65)]
+        [InlineData(27.3)]
+        public void InvalidLatIsTrue(decimal lat)
+        {
+            Assert.True(GeoCoordHelper.InvalidLat(lat));
+        }
+
+        [Theory]
+        [InlineData(0.00)]
+        [InlineData(-82.876)]
+        public void InvalidLongIsFalse(decimal lng)
+        {
+            Assert.False(GeoCoordHelper.InvalidLong(lng));
+        }
+
+        [Theory]
+        [InlineData(-79.86)]
+        [InlineData(-91.23)]
+        [InlineData(83.765)]
+        public void InvalidLongIsTrue(decimal lng)
+        {
+            Assert.True(GeoCoordHelper.InvalidLong(lng));
+        }
+
+        [Theory]
+        [InlineData(0.00, 0.00)]
+        [InlineData(32.876, -84.432)]
+        [InlineData(45.876, 86.54)]
+        public void BothZeroIsTrue(decimal lat, decimal lng)
+        {
+            Assert.True(GeoCoordHelper.BothZeros(lat, lng));
+        }
+
+        [Theory]
+        [InlineData(0.00, 23.356)]
+        [InlineData(23.543, 0.00)]
+        public void BothZeroIsFalse(decimal lat, decimal lng)
+        {
+            Assert.False(GeoCoordHelper.BothZeros(lat, lng));
+        }
+    }
+}

--- a/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
+++ b/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
@@ -7,54 +7,56 @@ namespace FMS.App.Tests.Helpers
         // Null values are filtered out by the form validation
 
         [Theory]
-        [InlineData(0.00)]
-        [InlineData(32.456)]
-        public void InvalidLatIsFalse(decimal lat)
+        [InlineData(0)]
+        [InlineData(32)]
+        public void ValidLat_ReturnsTrue_GiveValidLatitude(decimal lat)
         {
-            Assert.False(GeoCoordHelper.InvalidLat(lat));
+            Assert.True(GeoCoordHelper.ValidLat(lat));
         }
 
         [Theory]
-        [InlineData(37.23)]
-        [InlineData(38.65)]
-        [InlineData(27.3)]
-        public void InvalidLatIsTrue(decimal lat)
+        [InlineData(40)]
+        [InlineData(20)]
+        public void ValidLat_ReturnsFalse_GiveInvalidLatitude(decimal lat)
         {
-            Assert.True(GeoCoordHelper.InvalidLat(lat));
+            Assert.False(GeoCoordHelper.ValidLat(lat));
         }
 
         [Theory]
-        [InlineData(0.00)]
-        [InlineData(-82.876)]
-        public void InvalidLongIsFalse(decimal lng)
+        [InlineData(0)]
+        [InlineData(-82)]
+        public void ValidLon_ReturnsTrue_GiveValidLongitude(decimal lng)
         {
-            Assert.False(GeoCoordHelper.InvalidLong(lng));
+            Assert.True(GeoCoordHelper.ValidLong(lng));
         }
 
         [Theory]
-        [InlineData(-79.86)]
-        [InlineData(-91.23)]
-        [InlineData(83.765)]
-        public void InvalidLongIsTrue(decimal lng)
+        [InlineData(-70)]
+        [InlineData(-90)]
+        [InlineData(82)]
+        public void ValidLong_ReturnsFalse_GiveInvalidLongitude(decimal lng)
         {
-            Assert.True(GeoCoordHelper.InvalidLong(lng));
+            Assert.False(GeoCoordHelper.ValidLong(lng));
+        }
+
+        [Fact]
+        public void BothZeroOrBothNonzero_ReturnsTrue_GivenTwoZeros()
+        {
+            Assert.True(GeoCoordHelper.BothZeroOrBothNonzero(0, 0));
+        }
+
+        [Fact]
+        public void BothZeroOrBothNonzero_ReturnsTrue_GivenTwoNonZeros()
+        {
+            Assert.True(GeoCoordHelper.BothZeroOrBothNonzero(1, 1));
         }
 
         [Theory]
-        [InlineData(0.00, 0.00)]
-        [InlineData(32.876, -84.432)]
-        [InlineData(45.876, 86.54)]
-        public void BothZeroIsTrue(decimal lat, decimal lng)
+        [InlineData(0, 1)]
+        [InlineData(1, 0)]
+        public void BothZeroOrBothNonzero_ReturnsFalse_GivenOneZero(decimal lat, decimal lng)
         {
-            Assert.True(GeoCoordHelper.BothZeros(lat, lng));
-        }
-
-        [Theory]
-        [InlineData(0.00, 23.356)]
-        [InlineData(23.543, 0.00)]
-        public void BothZeroIsFalse(decimal lat, decimal lng)
-        {
-            Assert.False(GeoCoordHelper.BothZeros(lat, lng));
+            Assert.False(GeoCoordHelper.BothZeroOrBothNonzero(lat, lng));
         }
     }
 }

--- a/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
+++ b/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Text;
-using System.Threading.Tasks;
-using CsvHelper.Configuration;
-using FluentAssertions;
-using JetBrains.Annotations;
-using Xunit;
+﻿using Xunit;
 
 namespace FMS.App.Tests.Helpers
 {


### PR DESCRIPTION
Check to make sure Facility Geocoordinates are within State of Georgia.
First tried modifying Facility update in the repository, but it only shows an error to the user with no feedback. So, added to the Add and Edit Facility pages to give proper feedback to the user if invalid Latitude or Longitude are entered. 

closes: #182 