### PR TITLE
Fix paths in VS Code launch profiles

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/FMS/bin/Debug/net6.0/FMS.dll",
+            "program": "${workspaceFolder}/artifacts/FMS/bin/Debug/net6.0/FMS.dll",
             "args": [],
             "cwd": "${workspaceFolder}/FMS",
             "stopAtEntry": false,
@@ -35,7 +35,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/FMS/bin/Debug/net6.0/FMS.dll",
+            "program": "${workspaceFolder}/artifacts/FMS/bin/Debug/net6.0/FMS.dll",
             "args": [],
             "cwd": "${workspaceFolder}/FMS",
             "stopAtEntry": false,


### PR DESCRIPTION
VS Code was failing to enter debug mode when a fresh clone of the repo was opened.

The paths in the "launch.json" file were incorrect. They should have included the "artifacts" path. Once I made that change, debugging was successful.

fixes #204 