### PR TITLE
Enable NuGet central package management (CPM)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,29 +5,36 @@
   <ItemGroup>
     <PackageVersion Include="ClosedXML" Version="0.100.3" />
     <PackageVersion Include="Dapper" Version="2.0.123" />
-    <PackageVersion Include="EfCore.TestSupport" Version="5.2.2" />
+    <PackageVersion Include="EfCore.TestSupport" Version="5.3.0" />
     <PackageVersion Include="FreeSpire.PDF" Version="8.6.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.372" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.14">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="6.0.14" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="6.6.6" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.52.0.60960">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="FluentAssertions" Version="6.6.0" />
-    <PackageVersion Include="Moq" Version="4.17.2" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageVersion Include="xunit" Version="2.4.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageVersion Include="FluentAssertions" Version="6.10.0" />
+    <PackageVersion Include="Moq" Version="4.18.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,6 @@
     <PackageVersion Include="FreeSpire.PDF" Version="8.6.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2022.3.1" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.372" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.14" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.14" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.14" />
@@ -19,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="1.25.10" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="6.6.6" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.52.0.60960">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,10 @@
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.14" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.14" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.14" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.14">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.14">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,33 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="ClosedXML" Version="0.100.3" />
+    <PackageVersion Include="Dapper" Version="2.0.123" />
+    <PackageVersion Include="EfCore.TestSupport" Version="5.2.2" />
+    <PackageVersion Include="FreeSpire.PDF" Version="8.6.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2022.1.0" />
+    <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.372" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" />
+    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
+    <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="6.6.6" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Include="FluentAssertions" Version="6.6.0" />
+    <PackageVersion Include="Moq" Version="4.17.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageVersion Include="xunit" Version="2.4.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+</Project>

--- a/FMS.Domain/Entities/Users/ApplicationUser.cs
+++ b/FMS.Domain/Entities/Users/ApplicationUser.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 
 namespace FMS.Domain.Entities.Users
 {
@@ -22,25 +21,16 @@ namespace FMS.Domain.Entities.Users
         public string FamilyName { get; set; }
 
         /// <summary>
-        /// Equivalent to ExternalLoginInfo ProviderKey:
-        /// "The unique identifier for this user provided by the login provider."
-        /// Also ClaimTypes.NameIdentifier:
-        /// "The URI for a claim that specifies the name of an entity, http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier."
-        /// </summary>
-        [PersonalData]
-        public string SubjectId { get; set; }
-
-        /// <summary>
-        /// Equivalent to ClaimTypes.ObjectId:
-        /// "Old Object Id claim: http://schemas.microsoft.com/identity/claims/objectidentifier."
+        /// "oid: The object identifier for the user in Azure AD. This value is the immutable and non-reusable identifier
+        /// of the user. Use this value, not email, as a unique identifier for users; email addresses can change.
+        /// If you use the Azure AD Graph API in your app, object ID is that value used to query profile information."
+        /// https://learn.microsoft.com/en-us/azure/architecture/multitenant-identity/claims
+        ///
+        /// In ASP.NET Core, the OpenID Connect middleware converts some of the claim types when it populates the
+        /// Claims collection for the user principal:
+        /// oid -> http://schemas.microsoft.com/identity/claims/objectidentifier
         /// </summary>
         [PersonalData]
         public string ObjectId { get; set; }
-
-        public string DisplayName =>
-            string.Join(" ", new[] {GivenName, FamilyName}.Where(s => !string.IsNullOrEmpty(s)));
-
-        public string SortableFullName =>
-            string.Join(", ", new[] {FamilyName, GivenName}.Where(s => !string.IsNullOrEmpty(s)));
     }
 }

--- a/FMS.Domain/FMS.Domain.csproj
+++ b/FMS.Domain/FMS.Domain.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" Condition="'$(Configuration)' == 'Debug'">
+    <PackageReference Include="Microsoft.Extensions.Identity.Stores" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(Configuration)' == 'Debug'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" />
   </ItemGroup>
 
 </Project>

--- a/FMS.Domain/FMS.Domain.csproj
+++ b/FMS.Domain/FMS.Domain.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncFixer" Version="1.5.1" Condition="'$(Configuration)' == 'Debug'">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="6.0.4" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" Condition="'$(Configuration)' == 'Debug'">
       <PrivateAssets>all</PrivateAssets>

--- a/FMS.Domain/Services/UserView.cs
+++ b/FMS.Domain/Services/UserView.cs
@@ -1,15 +1,25 @@
 ﻿using System;
 using FMS.Domain.Entities.Users;
+using System.Linq;
 
 namespace FMS.Domain.Services
 {
     public class UserView
     {
-        public UserView(ApplicationUser user) =>
-            (Id, DisplayName, Email) = (user.Id, user.DisplayName, user.Email);
+        public UserView(ApplicationUser user)
+        {
+            Id = user.Id;
+            GivenName = user.GivenName;
+            FamilyName = user.FamilyName;
+            Email = user.Email;
+        }
 
         public Guid Id { get; }
-        public string DisplayName { get; }
+        private string GivenName { get; }
+        private string FamilyName { get; }
         public string Email { get; }
+
+        public string DisplayName =>
+            string.Join(" ", new[] { GivenName, FamilyName }.Where(s => !string.IsNullOrEmpty(s)));
     }
 }

--- a/FMS.Infrastructure/Contexts/FmsDbContextFactory.cs
+++ b/FMS.Infrastructure/Contexts/FmsDbContextFactory.cs
@@ -1,0 +1,21 @@
+﻿using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace FMS.Infrastructure.Contexts
+{
+    /// <summary>
+    /// Facilitates some EF Core Tools commands. See "Design-time DbContext Creation":
+    /// https://docs.microsoft.com/en-us/ef/core/cli/dbcontext-creation?tabs=dotnet-core-cli#from-a-design-time-factory
+    /// </summary>
+    [UsedImplicitly]
+    public class FmsDbContextFactory : IDesignTimeDbContextFactory<FmsDbContext>
+    {
+        public FmsDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<FmsDbContext>();
+            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=fms-temp;");
+            return new FmsDbContext(optionsBuilder.Options, null);
+        }
+    }
+}

--- a/FMS.Infrastructure/FMS.Infrastructure.csproj
+++ b/FMS.Infrastructure/FMS.Infrastructure.csproj
@@ -7,9 +7,14 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" />
+    <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.AspNetCore.Http" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(Configuration)' == 'Debug'">
       <PrivateAssets>all</PrivateAssets>

--- a/FMS.Infrastructure/FMS.Infrastructure.csproj
+++ b/FMS.Infrastructure/FMS.Infrastructure.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncFixer" Version="1.5.1" Condition="'$(Configuration)' == 'Debug'">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.4" />

--- a/FMS.Infrastructure/FMS.Infrastructure.csproj
+++ b/FMS.Infrastructure/FMS.Infrastructure.csproj
@@ -6,12 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" Condition="'$(Configuration)' == 'Debug'">
+    <PackageReference Include="Dapper" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(Configuration)' == 'Debug'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FMS.Infrastructure/Migrations/20230208145526_UpdateAppUserModel.Designer.cs
+++ b/FMS.Infrastructure/Migrations/20230208145526_UpdateAppUserModel.Designer.cs
@@ -4,6 +4,7 @@ using FMS.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FMS.Infrastructure.Migrations
 {
     [DbContext(typeof(FmsDbContext))]
-    partial class FmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230208145526_UpdateAppUserModel")]
+    partial class UpdateAppUserModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FMS.Infrastructure/Migrations/20230208145526_UpdateAppUserModel.cs
+++ b/FMS.Infrastructure/Migrations/20230208145526_UpdateAppUserModel.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FMS.Infrastructure.Migrations
+{
+    public partial class UpdateAppUserModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubjectId",
+                table: "AppUsers");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SubjectId",
+                table: "AppUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/FMS/FMS.csproj
+++ b/FMS/FMS.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AsyncFixer" Version="1.5.1" Condition="'$(Configuration)' == 'Debug'">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="ClosedXML" Version="0.100.3" />
     <PackageReference Include="FreeSpire.PDF" Version="8.6.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />

--- a/FMS/FMS.csproj
+++ b/FMS/FMS.csproj
@@ -14,13 +14,11 @@
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Condition="'$(Configuration)' == 'Debug'" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
     <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" />
     <PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(Configuration)' == 'Debug'">

--- a/FMS/FMS.csproj
+++ b/FMS/FMS.csproj
@@ -9,21 +9,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClosedXML" Version="0.100.3" />
-    <PackageReference Include="FreeSpire.PDF" Version="8.6.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
-    <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.372" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.4" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.4">
+    <PackageReference Include="ClosedXML" />
+    <PackageReference Include="FreeSpire.PDF" />
+    <PackageReference Include="JetBrains.Annotations" />
+    <PackageReference Include="LigerShark.WebOptimizer.Core" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.3" Condition="'$(Configuration)' == 'Debug'" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
-    <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" Version="6.6.6" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.38.0.46746" Condition="'$(Configuration)' == 'Debug'">
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
+    <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(Configuration)' == 'Debug'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FMS/FMS.csproj
+++ b/FMS/FMS.csproj
@@ -13,12 +13,12 @@
     <PackageReference Include="FreeSpire.PDF" />
     <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Identity.Web" />
     <PackageReference Include="Microsoft.Web.LibraryManager.Build" />
     <PackageReference Include="Mindscape.Raygun4Net.AspNetCore" />
     <PackageReference Include="SonarAnalyzer.CSharp" Condition="'$(Configuration)' == 'Debug'">

--- a/FMS/Pages/Account/ExternalLogin.cshtml
+++ b/FMS/Pages/Account/ExternalLogin.cshtml
@@ -40,12 +40,6 @@
         @Html.DisplayFor(m => m.DisplayFailedUser.GivenName)
     </dd>
     <dt class="col-sm-3">
-        @Html.DisplayNameFor(m => m.DisplayFailedUser.SubjectId)
-    </dt>
-    <dd class="col-sm-9">
-        @Html.DisplayFor(m => m.DisplayFailedUser.SubjectId)
-    </dd>
-    <dt class="col-sm-3">
         @Html.DisplayNameFor(m => m.DisplayFailedUser.ObjectId)
     </dt>
     <dd class="col-sm-9">

--- a/FMS/Pages/Account/Logout.cshtml.cs
+++ b/FMS/Pages/Account/Logout.cshtml.cs
@@ -1,6 +1,7 @@
 using FMS.Domain.Entities.Users;
 using FMS.Platform.Extensions.DevHelpers;
-using Microsoft.AspNetCore.Authentication.AzureAD.UI;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Identity;
@@ -13,23 +14,31 @@ namespace FMS.Pages.Account
     [AllowAnonymous]
     public class LogoutModel : PageModel
     {
-        public IActionResult OnGet() => RedirectToPage("/Index");
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly IWebHostEnvironment _environment;
 
-#pragma warning disable 618
-        public async Task<IActionResult> OnPostAsync(
-            [FromServices] SignInManager<ApplicationUser> signInManager,
-            [FromServices] IWebHostEnvironment environment)
+        public LogoutModel(SignInManager<ApplicationUser> signInManager, IWebHostEnvironment environment)
         {
-            if (!environment.IsLocalEnv())
+            _signInManager = signInManager;
+            _environment = environment;
+        }
+
+        public Task<IActionResult> OnGetAsync() => LogOutAndRedirectToIndex();
+        public Task<IActionResult> OnPostAsync() => LogOutAndRedirectToIndex();
+
+        private async Task<IActionResult> LogOutAndRedirectToIndex()
+        {
+            // If Azure AD is enabled, sign out all authentication schemes.
+            if (!_environment.IsLocalEnv())
             {
-                return SignOut(IdentityConstants.ApplicationScheme, IdentityConstants.ExternalScheme,
-                    AzureADDefaults.OpenIdScheme);
+                return SignOut(new AuthenticationProperties { RedirectUri = "/Index" },
+                    IdentityConstants.ApplicationScheme,
+                    OpenIdConnectDefaults.AuthenticationScheme);
             }
 
-            // If "test" users is enabled, sign out locally and redirect to home page.
-            await signInManager.SignOutAsync();
+            // If a local user is enabled instead, sign out locally and redirect to home page.
+            await _signInManager.SignOutAsync();
             return RedirectToPage("/Index");
         }
-#pragma warning restore 618
     }
 }

--- a/FMS/Properties/launchSettings.json
+++ b/FMS/Properties/launchSettings.json
@@ -14,8 +14,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44362;http://localhost:53734",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Local",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        "ASPNETCORE_ENVIRONMENT": "Local"
       }
     },
     "FMS Dev Server": {
@@ -24,8 +23,7 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:44362;http://localhost:53734",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES": "Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       }
     }
   }

--- a/FMS/Startup.cs
+++ b/FMS/Startup.cs
@@ -1,5 +1,3 @@
-using System;
-using System.IO;
 using FMS.Domain.Entities.Users;
 using FMS.Domain.Repositories;
 using FMS.Domain.Services;
@@ -8,19 +6,18 @@ using FMS.Infrastructure.Repositories;
 using FMS.Infrastructure.Services;
 using FMS.Platform.Extensions.DevHelpers;
 using FMS.Services;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.AzureAD.UI;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Identity.Web;
 using Mindscape.Raygun4Net.AspNetCore;
+using System;
+using System.IO;
 
 namespace FMS
 {
@@ -42,28 +39,12 @@ namespace FMS
                 .AddRoles<IdentityRole<Guid>>()
                 .AddEntityFrameworkStores<FmsDbContext>();
 
-            // Configure cookies
-            // SameSiteMode.None is needed to get single sign-out to work
-            services.Configure<CookiePolicyOptions>(opts => opts.MinimumSameSitePolicy = SameSiteMode.None);
-
             // Configure authentication
-            // (AddAzureAD is marked as obsolete and will be removed in a future version, but
-            // the replacement, Microsoft Identity Web, is net yet compatible with RoleManager.)
-            // Follow along at https://github.com/AzureAD/microsoft-identity-web/issues/1091
-#pragma warning disable 618
-            services.AddAuthentication().AddAzureAD(opts =>
-            {
-                Configuration.Bind(AzureADDefaults.AuthenticationScheme, opts);
-                opts.CallbackPath = "/signin-oidc";
-                opts.CookieSchemeName = "Identity.External";
-            });
-            services.Configure<OpenIdConnectOptions>(AzureADDefaults.OpenIdScheme, opts =>
-            {
-                opts.Authority += "/v2.0/";
-                opts.TokenValidationParameters.ValidateIssuer = true;
-                opts.UsePkce = true;
-            });
-#pragma warning restore 618
+            // An Azure AD app must be registered and configured in the settings file.
+            services.AddAuthentication().AddMicrosoftIdentityWebApp(Configuration, cookieScheme: null);
+            // Note: `cookieScheme: null` is mandatory. See https://github.com/AzureAD/microsoft-identity-web/issues/133#issuecomment-739550416
+
+            // Persist data protection keys
             var keysFolder = Path.Combine(Configuration["PersistedFilesBasePath"], "DataProtectionKeys");
             services.AddDataProtection().PersistKeysToFileSystem(Directory.CreateDirectory(keysFolder));
 
@@ -74,7 +55,8 @@ namespace FMS
             services.AddHsts(opts => { opts.MaxAge = TimeSpan.FromDays(365 * 2); });
 
             // Configure Raygun
-            services.AddRaygun(Configuration, new RaygunMiddlewareSettings {
+            services.AddRaygun(Configuration, new RaygunMiddlewareSettings
+            {
                 ClientProvider = new RaygunClientProvider()
             });
 
@@ -100,7 +82,7 @@ namespace FMS
 
             // Set up database
             services.AddHostedService<MigratorHostedService>();
-            
+
             // Configure bundling and minification.
             services.AddWebOptimizer();
         }
@@ -113,6 +95,7 @@ namespace FMS
                 // Local development environment
                 app.UseDeveloperExceptionPage();
             }
+
             if (env.IsDevelopment())
             {
                 // Dev web server

--- a/FMS/appsettings.json
+++ b/FMS/appsettings.json
@@ -7,7 +7,7 @@
     "Domain": "[Enter the domain of your tenant, e.g. contoso.onmicrosoft.com]",
     "TenantId": "[Enter the Directory (tenant) ID from the Azure portal]",
     "ClientId": "[Enter the Application (client) ID from the Azure portal]",
-    "ClientSecret": "[Enter a Client Secret from the Azure portal]"
+    "CallbackPath": "/signin-oidc"
   },
   "SeedAdminUsers": [
     "test.user@example.com"

--- a/README.md
+++ b/README.md
@@ -13,8 +13,18 @@ There are two launch profiles:
 
 * "FMS Local" -- Does not connect to any external server and no VPN access is needed (or even internet access except to load Google Maps). Uses LocalDB for storage with seed data and creates a local user account.
 
-* "FMS Dev Server" -- Connects to the dev database server so it requires a VPN connection. Uses your SOG account to log in. *To use this profile, you must add the "appsettings.Development.json" file from the "app-config" repo.*
+* "FMS Dev Server" -- Connects to the dev database server, so it requires a VPN connection. Uses your SOG account to log in. *To use this profile, you must add the "appsettings.Development.json" file from the "app-config" repo.*
 
 Most development should be done using the Local profile. The Dev Server profile is only needed when specifically troubleshooting issues with the database server or SOG account.
 
-**NOTE:** In order to load Google Maps on the Location Search page, you must add a Google API key in the "appsettings.json" file.
+**NOTE:** In order to load Google Maps on the Location Search page, you must add a Google API key in the "appsettings.Local.json" or "appsettings.Development.json" file.
+
+### Entity Framework database migrations
+
+Instructions for adding a new Entity Framework database migration:
+
+1. Open a command prompt to the root folder of the solution.
+
+2. Run the following command with an appropriate migration name:
+
+   `dotnet ef migrations add NAME_OF_MIGRATION --msbuildprojectextensionspath ..\artifacts\FMS.Infrastructure\obj\`

--- a/tests/FMS.App.Tests/FMS.App.Tests.csproj
+++ b/tests/FMS.App.Tests/FMS.App.Tests.csproj
@@ -6,12 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.17.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/FMS.App.Tests/FMS.App.Tests.csproj
+++ b/tests/FMS.App.Tests/FMS.App.Tests.csproj
@@ -9,6 +9,10 @@
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FMS.Domain.Tests/FMS.Domain.Tests.csproj
+++ b/tests/FMS.Domain.Tests/FMS.Domain.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FMS.Domain.Tests/FMS.Domain.Tests.csproj
+++ b/tests/FMS.Domain.Tests/FMS.Domain.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
+++ b/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
@@ -8,6 +8,10 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
+++ b/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/TestHelpers/TestHelpers.csproj
+++ b/tests/TestHelpers/TestHelpers.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="EfCore.TestSupport" />
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/TestHelpers/TestHelpers.csproj
+++ b/tests/TestHelpers/TestHelpers.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EfCore.TestSupport" Version="5.2.2" />
+    <PackageReference Include="EfCore.TestSupport" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request moves all the NuGet versioning info into a single file, simplifying updates and ensuring consistency between projects. Note that you may have to update your tooling (Visual Studio, etc.). See [Central Package Management | Microsoft Learn](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management) for details.

> Starting with NuGet 6.2, you can centrally manage your dependencies in your projects with the addition of a `Directory.Packages.props` file and an MSBuild property.

I also removed a few packages that were no longer helpful: 

* `AsyncFixer`: This never seemed to offer any helpful suggestions.
* `Microsoft.VisualStudio.Web.CodeGeneration.Design`: Command-line tool for scaffolding Razor pages, no longer needed. (I can't remember if it was ever used in the first place.) If scaffolding is desired for future dev work, it can be added back as needed.
* `Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation`: [Hot Reload support](https://learn.microsoft.com/en-us/aspnet/core/test/hot-reload?view=aspnetcore-6.0) (added in .NET 6) is a better solution.

*(The work in this PR was originally included in #221, but it caused conflicts with recent changes, so I separated it out to make code review and updates simpler.)*
