### PR TITLE
Use NSubstitute for unit test mocking

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,7 +26,7 @@
     <PackageVersion Include="Microsoft.Identity.Web" Version="2.7.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="6.6.6" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.7.0.75501">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -26,6 +26,8 @@
     <PackageVersion Include="Microsoft.Identity.Web" Version="2.7.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="6.6.6" />
+    <PackageVersion Include="NSubstitute" Version="5.0.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.16" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.7.0.75501">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -34,7 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="FluentAssertions" Version="6.10.0" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5">

--- a/tests/FMS.App.Tests/Account/AccountIndexTests.cs
+++ b/tests/FMS.App.Tests/Account/AccountIndexTests.cs
@@ -5,7 +5,7 @@ using FMS.Domain.Entities.Users;
 using FMS.Domain.Services;
 using FMS.Pages.Account;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace FMS.App.Tests.Account
@@ -23,11 +23,9 @@ namespace FMS.App.Tests.Account
                 FamilyName = "User"
             });
 
-            var mockUserService = new Mock<IUserService>();
-            mockUserService.Setup(l => l.GetCurrentUserAsync())
-                .ReturnsAsync(userView)
-                .Verifiable();
-            var pageModel = new IndexModel(mockUserService.Object);
+            var mockUserService = Substitute.For<IUserService>();
+            mockUserService.GetCurrentUserAsync().Returns(userView);
+            var pageModel = new IndexModel(mockUserService);
 
             var result = await pageModel.OnGetAsync().ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/Cabinets/CabinetAddTests.cs
+++ b/tests/FMS.App.Tests/Cabinets/CabinetAddTests.cs
@@ -6,7 +6,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Cabinets;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
 
@@ -17,10 +17,8 @@ namespace FMS.App.Tests.Cabinets
         [Fact]
         public async Task OnPost_ValidModel_ReturnsDetailsPage()
         {
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.CabinetNameExistsAsync(It.IsAny<string>(), It.IsAny<Guid?>()))
-                .ReturnsAsync(false);
-            mockRepo.Setup(l => l.CreateCabinetAsync(It.IsAny<CabinetEditDto>()));
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.CabinetNameExistsAsync(Arg.Any<string>(), Arg.Any<Guid?>()).Returns(false);
 
             var newCabinet = new CabinetEditDto()
             {
@@ -28,7 +26,7 @@ namespace FMS.App.Tests.Cabinets
                 FirstFileLabel = "999-9999",
             };
 
-            var pageModel = new AddModel(mockRepo.Object) {NewCabinet = newCabinet};
+            var pageModel = new AddModel(mockRepo) {NewCabinet = newCabinet};
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
 
@@ -41,8 +39,8 @@ namespace FMS.App.Tests.Cabinets
         [Fact]
         public async Task OnPost_IfInvalidModel_ReturnsPageWithInvalidModelState()
         {
-            var mockRepo = new Mock<ICabinetRepository>();
-            var pageModel = new AddModel(mockRepo.Object);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            var pageModel = new AddModel(mockRepo);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);

--- a/tests/FMS.App.Tests/Cabinets/CabinetDetailsTests.cs
+++ b/tests/FMS.App.Tests/Cabinets/CabinetDetailsTests.cs
@@ -4,7 +4,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Cabinets;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -19,12 +19,10 @@ namespace FMS.App.Tests.Cabinets
             var id = RepositoryData.Cabinets[0].Id;
             var item = ResourceHelper.GetCabinetSummary(id);
 
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.GetCabinetSummaryAsync(It.IsAny<string>()))
-                .ReturnsAsync(item)
-                .Verifiable();
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.GetCabinetSummaryAsync(Arg.Any<string>()).Returns(item);
 
-            var pageModel = new DetailsModel(mockRepo.Object);
+            var pageModel = new DetailsModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(item.Name).ConfigureAwait(false);
 
@@ -35,8 +33,8 @@ namespace FMS.App.Tests.Cabinets
         [Fact]
         public async Task OnGet_NonexistentIdReturnsNotFound()
         {
-            var mockRepo = new Mock<ICabinetRepository>();
-            var pageModel = new DetailsModel(mockRepo.Object);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            var pageModel = new DetailsModel(mockRepo);
 
             var result = await pageModel.OnGetAsync("zzz").ConfigureAwait(false);
 
@@ -47,8 +45,8 @@ namespace FMS.App.Tests.Cabinets
         [Fact]
         public async Task OnGet_MissingIdReturnsNotFound()
         {
-            var mockRepo = new Mock<ICabinetRepository>();
-            var pageModel = new DetailsModel(mockRepo.Object);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            var pageModel = new DetailsModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(string.Empty).ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/Cabinets/CabinetEditTests.cs
+++ b/tests/FMS.App.Tests/Cabinets/CabinetEditTests.cs
@@ -6,7 +6,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Cabinets;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -20,11 +20,9 @@ namespace FMS.App.Tests.Cabinets
         {
             var cabinet = RepositoryData.Cabinets[0];
             var expected = new CabinetSummaryDto(cabinet);
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.GetCabinetSummaryAsync(cabinet.Id))
-                .ReturnsAsync(expected)
-                .Verifiable();
-            var pageModel = new EditModel(mockRepo.Object);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.GetCabinetSummaryAsync(cabinet.Id).Returns(expected);
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(cabinet.Id).ConfigureAwait(false);
 
@@ -37,12 +35,10 @@ namespace FMS.App.Tests.Cabinets
         [Fact]
         public async Task OnGet_NonexistentId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.GetCabinetSummaryAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((CabinetSummaryDto) null)
-                .Verifiable();
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.GetCabinetSummaryAsync(Arg.Any<Guid>()).Returns((CabinetSummaryDto)null);
 
-            var pageModel = new EditModel(mockRepo.Object);
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -55,8 +51,8 @@ namespace FMS.App.Tests.Cabinets
         [Fact]
         public async Task OnGet_MissingId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<ICabinetRepository>();
-            var pageModel = new EditModel(mockRepo.Object);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 
@@ -71,13 +67,11 @@ namespace FMS.App.Tests.Cabinets
         {
             var cabinet = new CabinetSummaryDto(RepositoryData.Cabinets[0]);
 
-            var mockRepo = new Mock<ICabinetRepository>();
+            var mockRepo = Substitute.For<ICabinetRepository>();
 
-            mockRepo.Setup(l => l.CabinetNameExistsAsync(It.IsAny<string>(), It.IsAny<Guid?>()))
-                .ReturnsAsync(false);
-            mockRepo.Setup(l => l.UpdateCabinetAsync(It.IsAny<Guid>(), It.IsAny<CabinetEditDto>()));
-
-            var pageModel = new EditModel(mockRepo.Object)
+            mockRepo.CabinetNameExistsAsync(Arg.Any<string>(), Arg.Any<Guid?>()).Returns(false);
+            
+            var pageModel = new EditModel(mockRepo)
             {
                 Id = Guid.NewGuid(),
                 CabinetEdit = new CabinetEditDto(cabinet),
@@ -96,11 +90,10 @@ namespace FMS.App.Tests.Cabinets
         {
             var cabinet = new CabinetSummaryDto(RepositoryData.Cabinets[0]);
 
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.GetCabinetSummaryAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(cabinet);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.GetCabinetSummaryAsync(Arg.Any<Guid>()).Returns(cabinet);
             
-            var pageModel = new EditModel(mockRepo.Object);
+            var pageModel = new EditModel(mockRepo);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
@@ -115,13 +108,11 @@ namespace FMS.App.Tests.Cabinets
         {
             var cabinet = new CabinetSummaryDto(RepositoryData.Cabinets[0]);
 
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.CabinetNameExistsAsync(It.IsAny<string>(), It.IsAny<Guid>()))
-                .ReturnsAsync(true).Verifiable();
-            mockRepo.Setup(l => l.GetCabinetSummaryAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(cabinet);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.CabinetNameExistsAsync(Arg.Any<string>(), Arg.Any<Guid>()).Returns(true);
+            mockRepo.GetCabinetSummaryAsync(Arg.Any<Guid>()).Returns(cabinet);
 
-            var pageModel = new EditModel(mockRepo.Object)
+            var pageModel = new EditModel(mockRepo)
             {
                 Id = Guid.NewGuid(),
                 CabinetEdit = new CabinetEditDto(cabinet)
@@ -142,13 +133,11 @@ namespace FMS.App.Tests.Cabinets
             const string newFileLabel = "abc";
             var cabinet = new CabinetSummaryDto(RepositoryData.Cabinets[0]);
 
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.CabinetNameExistsAsync(It.IsAny<string>(), It.IsAny<Guid>()))
-                .ReturnsAsync(false);
-            mockRepo.Setup(l => l.GetCabinetSummaryAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(cabinet);
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.CabinetNameExistsAsync(Arg.Any<string>(), Arg.Any<Guid>()).Returns(false);
+            mockRepo.GetCabinetSummaryAsync(Arg.Any<Guid>()).Returns(cabinet);
 
-            var pageModel = new EditModel(mockRepo.Object)
+            var pageModel = new EditModel(mockRepo)
             {
                 Id = Guid.NewGuid(),
                 CabinetEdit = new CabinetEditDto(cabinet)

--- a/tests/FMS.App.Tests/Cabinets/CabinetIndexTests.cs
+++ b/tests/FMS.App.Tests/Cabinets/CabinetIndexTests.cs
@@ -3,7 +3,7 @@ using FluentAssertions;
 using FMS.Domain.Repositories;
 using FMS.Pages.Cabinets;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 
@@ -16,12 +16,10 @@ namespace FMS.App.Tests.Cabinets
         {
             var cabinets = ResourceHelper.GetCabinetSummaries(true);
 
-            var mockRepo = new Mock<ICabinetRepository>();
-            mockRepo.Setup(l => l.GetCabinetListAsync(true))
-                .ReturnsAsync(cabinets)
-                .Verifiable();
+            var mockRepo = Substitute.For<ICabinetRepository>();
+            mockRepo.GetCabinetListAsync(true).Returns(cabinets);
 
-            var pageModel = new IndexModel(mockRepo.Object);
+            var pageModel = new IndexModel(mockRepo);
 
             var result = await pageModel.OnGetAsync().ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/FMS.App.Tests.csproj
+++ b/tests/FMS.App.Tests/FMS.App.Tests.csproj
@@ -8,7 +8,11 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="SonarAnalyzer.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/FMS.App.Tests/Facilities/FacilityAddTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityAddTests.cs
@@ -7,7 +7,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
 
@@ -18,9 +18,9 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_PopulatesThePageModel()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new AddModel(mockRepo, mockSelectListHelper);
 
             var result = await pageModel.OnGetAsync().ConfigureAwait(false);
 
@@ -34,14 +34,12 @@ namespace FMS.App.Tests.Facilities
             // ReSharper disable once CollectionNeverUpdated.Local
             var nearbyFacilities = new List<FacilityMapSummaryDto>();
             var newId = Guid.NewGuid();
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.CreateFacilityAsync(It.IsAny<FacilityCreateDto>()))
-                .ReturnsAsync(newId);
-            mockRepo.Setup(l => l.GetFacilityListAsync(It.IsAny<FacilityMapSpec>()))
-                .ReturnsAsync(nearbyFacilities);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.CreateFacilityAsync(Arg.Any<FacilityCreateDto>()).Returns(newId);
+            mockRepo.GetFacilityListAsync(Arg.Any<FacilityMapSpec>()).Returns(nearbyFacilities);
 
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object)
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new AddModel(mockRepo, mockSelectListHelper)
             {
                 Facility = new FacilityCreateDto {State = "Georgia", Latitude = 0, Longitude = 0},
             };
@@ -68,12 +66,11 @@ namespace FMS.App.Tests.Facilities
                 }
             };
 
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityListAsync(It.IsAny<FacilityMapSpec>()))
-                .ReturnsAsync(nearbyFacilities);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityListAsync(Arg.Any<FacilityMapSpec>()).Returns(nearbyFacilities);
 
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object)
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new AddModel(mockRepo, mockSelectListHelper)
             {
                 Facility = new FacilityCreateDto {State = "Georgia", Latitude = 0, Longitude = 0},
             };
@@ -89,9 +86,9 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnPost_InvalidModel_ReturnsPageWithInvalidModelState()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new AddModel(mockRepo, mockSelectListHelper);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
@@ -105,15 +102,12 @@ namespace FMS.App.Tests.Facilities
         public async Task OnPostConfirm_ValidModel_ReturnsDetailsPage()
         {
             var newId = Guid.NewGuid();
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.CreateFacilityAsync(It.IsAny<FacilityCreateDto>()))
-                .ReturnsAsync(newId)
-                .Verifiable();
-            mockRepo.Setup(l => l.FileLabelExists(It.IsAny<string>()))
-                .ReturnsAsync(true);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.CreateFacilityAsync(Arg.Any<FacilityCreateDto>()).Returns(newId);
+            mockRepo.FileLabelExists(Arg.Any<string>()).Returns(true);
 
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object)
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new AddModel(mockRepo, mockSelectListHelper)
             {
                 Facility = new FacilityCreateDto {State = "Georgia"}
             };
@@ -130,9 +124,9 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnPostConfirm_InvalidModel_ReturnsPageWithInvalidModelState()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new AddModel(mockRepo, mockSelectListHelper);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnPostConfirmAsync().ConfigureAwait(false);

--- a/tests/FMS.App.Tests/Facilities/FacilityDeleteTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityDeleteTests.cs
@@ -6,7 +6,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -21,11 +21,9 @@ namespace FMS.App.Tests.Facilities
             var facilityId = RepositoryData.Facilities()[0].Id;
             var facility = ResourceHelper.GetFacilityDetail(facilityId);
 
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(facility)
-                .Verifiable();
-            var pageModel = new DeleteModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns(facility);
+            var pageModel = new DeleteModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(facility.Id).ConfigureAwait(false);
 
@@ -37,12 +35,10 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_NonexistentId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((FacilityDetailDto) null)
-                .Verifiable();
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns((FacilityDetailDto) null);
 
-            var pageModel = new DeleteModel(mockRepo.Object);
+            var pageModel = new DeleteModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -54,8 +50,8 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_MissingId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var pageModel = new DeleteModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var pageModel = new DeleteModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 
@@ -68,10 +64,9 @@ namespace FMS.App.Tests.Facilities
         public async Task OnPost_IfValidModel_ReturnsDetailsPage()
         {
             var id = Guid.NewGuid();
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.DeleteFacilityAsync(It.IsAny<Guid>()));
-
-            var pageModel = new DeleteModel(mockRepo.Object)
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            
+            var pageModel = new DeleteModel(mockRepo)
             {
                 Id = id,
             };

--- a/tests/FMS.App.Tests/Facilities/FacilityDetailsTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityDetailsTests.cs
@@ -5,7 +5,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -20,12 +20,10 @@ namespace FMS.App.Tests.Facilities
             var facilityId = RepositoryData.Facilities()[0].Id;
             var facility = ResourceHelper.GetFacilityDetail(facilityId);
 
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(facility)
-                .Verifiable();
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns(facility);
 
-            var pageModel = new DetailsModel(mockRepo.Object);
+            var pageModel = new DetailsModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(facility.Id, null).ConfigureAwait(false);
 
@@ -36,8 +34,8 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_NonexistentIdReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var pageModel = new DetailsModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var pageModel = new DetailsModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty, null).ConfigureAwait(false);
 
@@ -48,8 +46,8 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_MissingIdReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var pageModel = new DetailsModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var pageModel = new DetailsModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(null, null).ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/Facilities/FacilityEditTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityEditTests.cs
@@ -6,7 +6,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -21,13 +21,11 @@ namespace FMS.App.Tests.Facilities
             var facilityId = RepositoryData.Facilities()[0].Id;
             var facility = ResourceHelper.GetFacilityDetail(facilityId);
 
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(facility)
-                .Verifiable();
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns(facility);
 
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new EditModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new EditModel(mockRepo, mockSelectListHelper);
 
             var result = await pageModel.OnGetAsync(facility.Id).ConfigureAwait(false);
 
@@ -39,13 +37,11 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_NonexistentId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((FacilityDetailDto) null)
-                .Verifiable();
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns((FacilityDetailDto)null);
 
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new EditModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new EditModel(mockRepo, mockSelectListHelper);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -57,9 +53,9 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_MissingId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new EditModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new EditModel(mockRepo, mockSelectListHelper);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 
@@ -72,11 +68,10 @@ namespace FMS.App.Tests.Facilities
         public async Task OnPost_IfValidModel_ReturnsDetailsPage()
         {
             var id = Guid.NewGuid();
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.UpdateFacilityAsync(It.IsAny<Guid>(), It.IsAny<FacilityEditDto>()));
-
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new EditModel(mockRepo.Object, mockSelectListHelper.Object)
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new EditModel(mockRepo, mockSelectListHelper)
             {
                 Id = id,
                 Facility = new FacilityEditDto()
@@ -86,16 +81,16 @@ namespace FMS.App.Tests.Facilities
 
             result.Should().BeOfType<RedirectToPageResult>();
             pageModel.ModelState.IsValid.ShouldBeTrue();
-            ((RedirectToPageResult) result).PageName.Should().Be("./Details");
-            ((RedirectToPageResult) result).RouteValues["id"].Should().Be(id);
+            ((RedirectToPageResult)result).PageName.Should().Be("./Details");
+            ((RedirectToPageResult)result).RouteValues["id"].Should().Be(id);
         }
 
         [Fact]
         public async Task OnPost_IfInvalidModel_ReturnsPageWithInvalidModelState()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var mockSelectListHelper = new Mock<ISelectListHelper>();
-            var pageModel = new EditModel(mockRepo.Object, mockSelectListHelper.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+            var pageModel = new EditModel(mockRepo, mockSelectListHelper);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);

--- a/tests/FMS.App.Tests/Facilities/FacilityUndeleteTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityUndeleteTests.cs
@@ -6,7 +6,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -21,11 +21,9 @@ namespace FMS.App.Tests.Facilities
             var facilityId = RepositoryData.Facilities()[0].Id;
             var facility = ResourceHelper.GetFacilityDetail(facilityId);
 
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(facility)
-                .Verifiable();
-            var pageModel = new UndeleteModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns(facility);
+            var pageModel = new UndeleteModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(facility.Id).ConfigureAwait(false);
 
@@ -37,12 +35,10 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_NonexistentId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.GetFacilityAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((FacilityDetailDto) null)
-                .Verifiable();
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns((FacilityDetailDto) null);
 
-            var pageModel = new UndeleteModel(mockRepo.Object);
+            var pageModel = new UndeleteModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -54,8 +50,8 @@ namespace FMS.App.Tests.Facilities
         [Fact]
         public async Task OnGet_MissingId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IFacilityRepository>();
-            var pageModel = new UndeleteModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            var pageModel = new UndeleteModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 
@@ -68,10 +64,9 @@ namespace FMS.App.Tests.Facilities
         public async Task OnPost_IfValidModel_ReturnsDetailsPage()
         {
             var id = Guid.NewGuid();
-            var mockRepo = new Mock<IFacilityRepository>();
-            mockRepo.Setup(l => l.UndeleteFacilityAsync(It.IsAny<Guid>()));
-
-            var pageModel = new UndeleteModel(mockRepo.Object)
+            var mockRepo = Substitute.For<IFacilityRepository>();
+            
+            var pageModel = new UndeleteModel(mockRepo)
             {
                 Id = id,
             };

--- a/tests/FMS.App.Tests/Files/FilesDetailsTests.cs
+++ b/tests/FMS.App.Tests/Files/FilesDetailsTests.cs
@@ -5,7 +5,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Files;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -19,10 +19,9 @@ namespace FMS.App.Tests.Files
         {
             var file = RepositoryData.Files[0];
 
-            var mockRepository = new Mock<IFileRepository>();
-            mockRepository.Setup(l => l.GetFileAsync(file.FileLabel))
-                .ReturnsAsync(new FileDetailDto(file));
-            var pageModel = new DetailsModel(mockRepository.Object);
+            var mockRepository = Substitute.For<IFileRepository>();
+            mockRepository.GetFileAsync(file.FileLabel).Returns(new FileDetailDto(file));
+            var pageModel = new DetailsModel(mockRepository);
 
             var result = await pageModel.OnGetAsync(file.FileLabel).ConfigureAwait(false);
 
@@ -33,11 +32,10 @@ namespace FMS.App.Tests.Files
         [Fact]
         public async Task OnGet_NonexistentIdReturnsNotFound()
         {
-            var mockRepository = new Mock<IFileRepository>();
-            mockRepository.Setup(l => l.GetFileAsync(It.IsAny<string>()))
-                .ReturnsAsync((FileDetailDto) null);
+            var mockRepository = Substitute.For<IFileRepository>();
+            mockRepository.GetFileAsync(Arg.Any<string>()).Returns((FileDetailDto) null);
 
-            var pageModel = new DetailsModel(mockRepository.Object);
+            var pageModel = new DetailsModel(mockRepository);
 
             var result = await pageModel.OnGetAsync("Test").ConfigureAwait(false);
 
@@ -48,8 +46,8 @@ namespace FMS.App.Tests.Files
         [Fact]
         public async Task OnGet_MissingIdReturnsNotFound()
         {
-            var mockRepository = new Mock<IFileRepository>();
-            var pageModel = new DetailsModel(mockRepository.Object);
+            var mockRepository = Substitute.For<IFileRepository>();
+            var pageModel = new DetailsModel(mockRepository);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/Files/FilesIndexTests.cs
+++ b/tests/FMS.App.Tests/Files/FilesIndexTests.cs
@@ -8,7 +8,7 @@ using FMS.Domain.Repositories;
 using FMS.Pages.Files;
 using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using TestHelpers;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
@@ -26,12 +26,10 @@ namespace FMS.App.Tests.Files
                 .ToList();
             var expected = new PaginatedList<FileDetailDto>(items, items.Count, 1, GlobalConstants.PageSize);
 
-            var mockRepository = new Mock<IFileRepository>();
+            var mockRepository = Substitute.For<IFileRepository>();
             var spec = new FileSpec();
-            mockRepository.Setup(l =>
-                    l.GetFileListAsync(It.IsAny<FileSpec>(), It.IsAny<int>(), It.IsAny<int>()))
-                .ReturnsAsync(expected).Verifiable();
-            var pageModel = new IndexModel(mockRepository.Object);
+            mockRepository.GetFileListAsync(Arg.Any<FileSpec>(), Arg.Any<int>(), Arg.Any<int>()).Returns(expected);
+            var pageModel = new IndexModel(mockRepository);
 
             var result = await pageModel.OnGetSearchAsync(spec).ConfigureAwait(false);
 
@@ -44,13 +42,11 @@ namespace FMS.App.Tests.Files
         [Fact]
         public async Task OnSearch_NoMatch_ReturnsEmptyList()
         {
-            var mockRepository = new Mock<IFileRepository>();
+            var mockRepository = Substitute.For<IFileRepository>();
             var spec = new FileSpec();
             var expected = new PaginatedList<FileDetailDto>(new List<FileDetailDto>(), 0, 1, GlobalConstants.PageSize);
-            mockRepository.Setup(l =>
-                    l.GetFileListAsync(It.IsAny<FileSpec>(), It.IsAny<int>(), It.IsAny<int>()))
-                .ReturnsAsync(expected).Verifiable();
-            var pageModel = new IndexModel(mockRepository.Object);
+            mockRepository.GetFileListAsync(Arg.Any<FileSpec>(), Arg.Any<int>(), Arg.Any<int>()).Returns(expected);
+            var pageModel = new IndexModel(mockRepository);
 
             var result = await pageModel.OnGetSearchAsync(spec).ConfigureAwait(false);
 
@@ -63,8 +59,8 @@ namespace FMS.App.Tests.Files
         [Fact]
         public async Task OnSearch_IfInvalidModel_ReturnPageWithInvalidModelState()
         {
-            var mockRepository = new Mock<IFileRepository>();
-            var pageModel = new IndexModel(mockRepository.Object);
+            var mockRepository = Substitute.For<IFileRepository>();
+            var pageModel = new IndexModel(mockRepository);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnGetSearchAsync(default).ConfigureAwait(false);

--- a/tests/FMS.App.Tests/Users/UserDetailsTests.cs
+++ b/tests/FMS.App.Tests/Users/UserDetailsTests.cs
@@ -5,7 +5,7 @@ using FMS.Domain.Services;
 using FMS.Pages.Users;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
 
@@ -18,12 +18,10 @@ namespace FMS.App.Tests.Users
         {
             var user = new UserView(UserTestData.ApplicationUsers[0]);
 
-            var mockUserService = new Mock<IUserService>();
-            mockUserService.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(user)
-                .Verifiable();
+            var mockUserService = Substitute.For<IUserService>();
+            mockUserService.GetUserByIdAsync(Arg.Any<Guid>()).Returns(user);
 
-            var pageModel = new DetailsModel(mockUserService.Object);
+            var pageModel = new DetailsModel(mockUserService);
 
             var result = await pageModel.OnGetAsync(user.Id).ConfigureAwait(false);
 
@@ -36,8 +34,8 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_NonexistentIdReturnsNotFound()
         {
-            var mockUserService = new Mock<IUserService>();
-            var pageModel = new DetailsModel(mockUserService.Object);
+            var mockUserService = Substitute.For<IUserService>();
+            var pageModel = new DetailsModel(mockUserService);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -49,8 +47,8 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_MissingIdReturnsNotFound()
         {
-            var mockUserService = new Mock<IUserService>();
-            var pageModel = new DetailsModel(mockUserService.Object);
+            var mockUserService = Substitute.For<IUserService>();
+            var pageModel = new DetailsModel(mockUserService);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/Users/UserEditTests.cs
+++ b/tests/FMS.App.Tests/Users/UserEditTests.cs
@@ -8,7 +8,7 @@ using FMS.Pages.Users;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
 
@@ -21,13 +21,11 @@ namespace FMS.App.Tests.Users
         {
             var user = new UserView(UserTestData.ApplicationUsers[0]);
 
-            var mockRepo = new Mock<IUserService>();
-            mockRepo.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(user);
-            mockRepo.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(new List<string>());
+            var mockRepo = Substitute.For<IUserService>();
+            mockRepo.GetUserByIdAsync(Arg.Any<Guid>()).Returns(user);
+            mockRepo.GetUserRolesAsync(Arg.Any<Guid>()).Returns(new List<string>());
 
-            var pageModel = new EditModel(mockRepo.Object);
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -53,13 +51,11 @@ namespace FMS.App.Tests.Users
                 UserRoles.UserMaintenance,
             };
 
-            var mockRepo = new Mock<IUserService>();
-            mockRepo.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(user);
-            mockRepo.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(roles);
+            var mockRepo = Substitute.For<IUserService>();
+            mockRepo.GetUserByIdAsync(Arg.Any<Guid>()).Returns(user);
+            mockRepo.GetUserRolesAsync(Arg.Any<Guid>()).Returns(roles);
 
-            var pageModel = new EditModel(mockRepo.Object);
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -76,8 +72,8 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_MissingId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IUserService>();
-            var pageModel = new EditModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IUserService>();
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(null).ConfigureAwait(false);
 
@@ -88,10 +84,9 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnGet_NonexistentId_ReturnsNotFound()
         {
-            var mockRepo = new Mock<IUserService>();
-            mockRepo.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync((UserView)null);
-            var pageModel = new EditModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IUserService>();
+            mockRepo.GetUserByIdAsync(Arg.Any<Guid>()).Returns((UserView)null);
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnGetAsync(Guid.Empty).ConfigureAwait(false);
 
@@ -102,11 +97,10 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnPost_ValidModel_ReturnsDetailsPage()
         {
-            var mockRepo = new Mock<IUserService>();
-            mockRepo.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))
-                .ReturnsAsync(IdentityResult.Success);
+            var mockRepo = Substitute.For<IUserService>();
+            mockRepo.UpdateUserRolesAsync(Arg.Any<Guid>(), Arg.Any<Dictionary<string, bool>>()).Returns(IdentityResult.Success);
 
-            var pageModel = new EditModel(mockRepo.Object)
+            var pageModel = new EditModel(mockRepo)
             {
                 UserId = Guid.Empty
             };
@@ -122,8 +116,8 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnPost_InvalidModel_ReturnsPageWithInvalidModelState()
         {
-            var mockRepo = new Mock<IUserService>();
-            var pageModel = new EditModel(mockRepo.Object);
+            var mockRepo = Substitute.For<IUserService>();
+            var pageModel = new EditModel(mockRepo);
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
@@ -140,15 +134,12 @@ namespace FMS.App.Tests.Users
             var identityResult = IdentityResult.Failed(
                 new IdentityError() { Code = "CODE", Description = "DESCRIPTION" });
 
-            var mockRepo = new Mock<IUserService>();
-            mockRepo.Setup(l => l.UpdateUserRolesAsync(It.IsAny<Guid>(), It.IsAny<Dictionary<string, bool>>()))
-                .ReturnsAsync(identityResult);
-            mockRepo.Setup(l => l.GetUserByIdAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(user);
-            mockRepo.Setup(l => l.GetUserRolesAsync(It.IsAny<Guid>()))
-                .ReturnsAsync(new List<string>());
+            var mockRepo = Substitute.For<IUserService>();
+            mockRepo.UpdateUserRolesAsync(Arg.Any<Guid>(), Arg.Any<Dictionary<string, bool>>()).Returns(identityResult);
+            mockRepo.GetUserByIdAsync(Arg.Any<Guid>()).Returns(user);
+            mockRepo.GetUserRolesAsync(Arg.Any<Guid>()).Returns(new List<string>());
 
-            var pageModel = new EditModel(mockRepo.Object);
+            var pageModel = new EditModel(mockRepo);
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
 

--- a/tests/FMS.App.Tests/Users/UserSearchTests.cs
+++ b/tests/FMS.App.Tests/Users/UserSearchTests.cs
@@ -4,7 +4,7 @@ using FluentAssertions;
 using FMS.Domain.Services;
 using FMS.Pages.Users;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Xunit.Extensions.AssertExtensions;
 
@@ -21,13 +21,11 @@ namespace FMS.App.Tests.Users
                 .Select(e => new UserView(e))
                 .ToList();
 
-            var mockUserService = new Mock<IUserService>();
-            mockUserService.Setup(l => l.GetUsersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .ReturnsAsync(searchResults)
-                .Verifiable();
+            var mockUserService = Substitute.For<IUserService>();
+            mockUserService.GetUsersAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(searchResults);
             var pageModel = new IndexModel();
 
-            var result = await pageModel.OnGetSearchAsync(mockUserService.Object, name, email, role)
+            var result = await pageModel.OnGetSearchAsync(mockUserService, name, email, role)
                 .ConfigureAwait(false);
 
             result.Should().BeOfType<PageResult>();
@@ -38,11 +36,11 @@ namespace FMS.App.Tests.Users
         [Fact]
         public async Task OnSearch_IfInvalidModel_ReturnPageWithInvalidModelState()
         {
-            var mockUserService = new Mock<IUserService>();
+            var mockUserService = Substitute.For<IUserService>();
             var pageModel = new IndexModel();
             pageModel.ModelState.AddModelError("Error", "Sample error description");
 
-            var result = await pageModel.OnGetSearchAsync(mockUserService.Object, null, null, null)
+            var result = await pageModel.OnGetSearchAsync(mockUserService, null, null, null)
                 .ConfigureAwait(false);
 
             result.Should().BeOfType<PageResult>();


### PR DESCRIPTION
Replaced the Moq package with NSubstitute and then updated the syntax throughout the unit tests. For the most part, NSubstitute has simpler syntax. Also, there were some Moq commands in use that didn't appear to serve any purpose. Those were removed rather than migrated to NSubstitute syntax.