### PR TITLE
311 remove taxid field from db and project

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilityCreateDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityCreateDto.cs
@@ -108,9 +108,6 @@ namespace FMS.Domain.Dto
         [Display(Name = "Historical C.O.")]
         public string HistoricalComplianceOfficer { get; set; }
 
-        [Display(Name = "Tax ID")]
-        public string TaxId { get; set; }
-
         [Display(Name = "Has Electronic Records")]
         public bool HasERecord { get; set; }
 
@@ -125,7 +122,6 @@ namespace FMS.Domain.Dto
             PostalCode = PostalCode?.Trim();
             HSInumber = HSInumber?.Trim();
             HistoricalUnit = HistoricalUnit?.Trim();
-            TaxId = TaxId?.Trim();
         }
     }
 }

--- a/FMS.Domain/Dto/Facility/FacilityDetailDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityDetailDto.cs
@@ -42,7 +42,6 @@ namespace FMS.Domain.Dto
             RNDateReceived = facility.RNDateReceived;
             HistoricalUnit = facility.HistoricalUnit;
             HistoricalComplianceOfficer = facility.HistoricalComplianceOfficer;
-            TaxId = facility.TaxId;
             HasERecord = facility.HasERecord;
             IsRetained = facility.IsRetained;
             Cabinets = new List<string>();
@@ -141,9 +140,6 @@ namespace FMS.Domain.Dto
 
         [Display(Name = "Historical C.O.")]
         public string HistoricalComplianceOfficer { get; set; }
-
-        [Display(Name = "Tax ID")]
-        public string TaxId { get; set; }
 
         [Display(Name = "Has Electronic Records")]
         public bool HasERecord { get; set; }

--- a/FMS.Domain/Dto/Facility/FacilityEditDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityEditDto.cs
@@ -38,7 +38,6 @@ namespace FMS.Domain.Dto
             RNDateReceived = facility.RNDateReceived;
             HistoricalUnit = facility.HistoricalUnit;
             HistoricalComplianceOfficer = facility.HistoricalComplianceOfficer;
-            TaxId = facility.TaxId;
             HasERecord = facility.HasERecord;
             IsRetained = facility.IsRetained;
         }
@@ -151,9 +150,6 @@ namespace FMS.Domain.Dto
         [Display(Name = "Historical Compliance Officer")]
         public string HistoricalComplianceOfficer { get; set; }
 
-        [Display(Name = "Tax ID")]
-        public string TaxId { get; set; }
-
         [Display(Name = "Has Electronic Records")]
         public bool HasERecord { get; set; }
 
@@ -168,7 +164,6 @@ namespace FMS.Domain.Dto
             PostalCode = PostalCode?.Trim();
             HSInumber = HSInumber?.Trim();
             HistoricalUnit = HistoricalUnit?.Trim();
-            TaxId = TaxId?.Trim();
         }
     }
 }

--- a/FMS.Domain/Dto/Facility/FacilitySpec.cs
+++ b/FMS.Domain/Dto/Facility/FacilitySpec.cs
@@ -93,9 +93,6 @@ namespace FMS.Domain.Dto
         [Display(Name = "Historical C.O.")]
         public string HistoricalComplianceOfficer { get; set; }
 
-        [Display(Name = "Tax ID")]
-        public string TaxId { get; set; }
-
         [Display(Name = "Has Electronic Records")]
         public bool HasERecord { get; set; }
 

--- a/FMS.Domain/Entities/Facility.cs
+++ b/FMS.Domain/Entities/Facility.cs
@@ -42,7 +42,6 @@ namespace FMS.Domain.Entities
             RNDateReceived = newFacility.RNDateReceived;
             HistoricalUnit = newFacility.HistoricalUnit;
             HistoricalComplianceOfficer = newFacility.HistoricalComplianceOfficer;
-            TaxId = newFacility.TaxId;
         }
 
         // Existing ID for Facility May be used by Programs - System Generated, but not a Guid
@@ -129,8 +128,6 @@ namespace FMS.Domain.Entities
         public string HistoricalUnit { get; set; }
 
         public string HistoricalComplianceOfficer { get; set; }
-
-        public string TaxId { get; set; }
 
         // List of retention records for this Facility
         public ICollection<RetentionRecord> RetentionRecords { get; set; }

--- a/FMS.Infrastructure/Migrations/20240205165242_RemoveTaxIDField.Designer.cs
+++ b/FMS.Infrastructure/Migrations/20240205165242_RemoveTaxIDField.Designer.cs
@@ -4,6 +4,7 @@ using FMS.Infrastructure.Contexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FMS.Infrastructure.Migrations
 {
     [DbContext(typeof(FmsDbContext))]
-    partial class FmsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240205165242_RemoveTaxIDField")]
+    partial class RemoveTaxIDField
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FMS.Infrastructure/Migrations/20240205165242_RemoveTaxIDField.cs
+++ b/FMS.Infrastructure/Migrations/20240205165242_RemoveTaxIDField.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FMS.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveTaxIDField : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TaxId",
+                table: "Facilities");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TaxId",
+                table: "Facilities",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+    }
+}

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -308,7 +308,6 @@ namespace FMS.Infrastructure.Repositories
             facility.RNDateReceived = facilityUpdates.RNDateReceived;
             facility.HistoricalUnit = facilityUpdates.HistoricalUnit;
             facility.HistoricalComplianceOfficer = facilityUpdates.HistoricalComplianceOfficer;
-            facility.TaxId = facilityUpdates.TaxId;
             // ******************
             facility.IsRetained = facilityUpdates.IsRetained;
 

--- a/FMS/Helpers/FacilityDetailDtoScalar.cs
+++ b/FMS/Helpers/FacilityDetailDtoScalar.cs
@@ -38,7 +38,6 @@ namespace FMS.Domain.Dto
             RNDateReceived = facility.RNDateReceived;
             HistoricalUnit = facility.HistoricalUnit;
             HistoricalComplianceOfficer = facility.HistoricalComplianceOfficer;
-            TaxId = facility.TaxId;
             HasERecord = facility.HasERecord;
             IsRetained = facility.IsRetained;
             Cabinets = facility.CabinetsToString;
@@ -131,9 +130,6 @@ namespace FMS.Domain.Dto
 
         [XLColumn(Header = "Historical C.O.")]
         public string HistoricalComplianceOfficer { get; set; }
-
-        [XLColumn(Header = "Tax ID")]
-        public string TaxId { get; set; }
 
         [XLColumn(Header = "Has Electronic Records")]
         public bool HasERecord { get; set; }

--- a/FMS/Pages/Facilities/Add.cshtml
+++ b/FMS/Pages/Facilities/Add.cshtml
@@ -191,10 +191,6 @@
                     <label asp-for="Facility.HSInumber"></label>
                     <input asp-for="Facility.HSInumber" class="form-control" />
                 </div>
-                <div class="col-md-6">
-                    <label asp-for="Facility.TaxId"></label>
-                    <input asp-for="Facility.TaxId" class="form-control" />
-                </div>
             </div>
             <div class="mb-3 row">
                 <div class="col-md-6">
@@ -302,7 +298,6 @@
                 <input asp-for="Facility.HSInumber" type="hidden" />
                 <input asp-for="Facility.DeterminationLetterDate" type="hidden" />
                 <input asp-for="Facility.Comments" type="hidden" />
-                <input asp-for="Facility.TaxId" type="hidden" />
                 <input asp-for="Facility.RNDateReceived" type="hidden" />
             </div>
         }

--- a/FMS/Pages/Facilities/Delete.cshtml
+++ b/FMS/Pages/Facilities/Delete.cshtml
@@ -167,12 +167,6 @@
                     <dd class="col-sm-7">
                         @Html.DisplayFor(model => model.FacilityDetail.HistoricalComplianceOfficer)
                     </dd>
-                    <dt class="col-sm-5">
-                        @Html.DisplayNameFor(model => model.FacilityDetail.TaxId)
-                    </dt>
-                    <dd class="col-sm-7">
-                        @Html.DisplayFor(model => model.FacilityDetail.TaxId)
-                    </dd>
                 </dl>
             </div>
         }

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -192,12 +192,6 @@
                     <dd class="col-sm-7">
                         @Html.DisplayFor(model => model.FacilityDetail.HistoricalComplianceOfficer)
                     </dd>
-                    <dt class="col-sm-5">
-                        @Html.DisplayNameFor(model => model.FacilityDetail.TaxId)
-                    </dt>
-                    <dd class="col-sm-7">
-                        @Html.DisplayFor(model => model.FacilityDetail.TaxId)
-                    </dd>
                 </dl>
             </div>
         }

--- a/FMS/Pages/Facilities/Edit.cshtml
+++ b/FMS/Pages/Facilities/Edit.cshtml
@@ -206,10 +206,6 @@
                     <label asp-for="Facility.HSInumber"></label>
                     <input asp-for="Facility.HSInumber" class="form-control" />
                 </div>
-                <div class="col-md-6">
-                    <label asp-for="Facility.TaxId"></label>
-                    <input asp-for="Facility.TaxId" class="form-control" />
-                </div>
             </div>
             <div class="mb-3 row">
                 <div class="col-md-6">

--- a/FMS/Pages/Facilities/Undelete.cshtml
+++ b/FMS/Pages/Facilities/Undelete.cshtml
@@ -167,12 +167,6 @@
                     <dd class="col-sm-7">
                         @Html.DisplayFor(model => model.FacilityDetail.HistoricalComplianceOfficer)
                     </dd>
-                    <dt class="col-sm-5">
-                        @Html.DisplayNameFor(model => model.FacilityDetail.TaxId)
-                    </dt>
-                    <dd class="col-sm-7">
-                        @Html.DisplayFor(model => model.FacilityDetail.TaxId)
-                    </dd>
                 </dl>
             </div>
         }

--- a/FMS/Platform/DevHelpers/SeedData/FacilitySeedData.cs
+++ b/FMS/Platform/DevHelpers/SeedData/FacilitySeedData.cs
@@ -344,7 +344,7 @@ namespace FMS.Platform.Extensions.DevHelpers.SeedData
                     Name = "Facility Test-4 Release Notification",
                     ComplianceOfficerId = new Guid("468F746A-270F-4584-8B04-71CD5271A40F"),
                     FacilityStatusId = new Guid("0FF0A063-2D11-4305-BADA-E9A4414EDDF1"),
-                    Location = "Some Random Strip Mall",
+                    Location = "Some Random Strip Mall <TaxID>102-395763-tk^other data",
                     Address = "10919 HWY 92",
                     City = "Woodstock",
                     State = "Georgia",

--- a/FMS/Platform/DevHelpers/SeedData/FacilitySeedData.cs
+++ b/FMS/Platform/DevHelpers/SeedData/FacilitySeedData.cs
@@ -330,7 +330,6 @@ namespace FMS.Platform.Extensions.DevHelpers.SeedData
                     RNDateReceived = null,
                     HistoricalUnit = "Old RRP Unit",
                     HistoricalComplianceOfficer = "Someone Retired",
-                    TaxId = "ABC-2637485-11",
                     IsRetained = true
                 },
                 new()
@@ -353,7 +352,6 @@ namespace FMS.Platform.Extensions.DevHelpers.SeedData
                     Latitude = 34.086774m,
                     Longitude = -84.506122m,
                     CountyId = 243,
-                    IsRetained = true,
                     HSInumber = "10251",
                     DeterminationLetterDate = null,
                     Comments = "Strip that looks like every other strip mall. Extra long comment to see how it fits on the page. Strip that looks like every other strip mall. Extra long comment to see how it fits on the page. Strip that looks like every other strip mall. Extra long comment to see how it fits on the page. Strip that looks like every other strip mall. Extra long comment to see how it fits on the page.",
@@ -365,7 +363,7 @@ namespace FMS.Platform.Extensions.DevHelpers.SeedData
                     RNDateReceived = new(2018, 2, 13),
                     HistoricalUnit = "Old RRP Unit",
                     HistoricalComplianceOfficer = "Another Retired",
-                    TaxId = "DEF-123456789-11"
+                    IsRetained = true,
                 }
             };
         }

--- a/README.md
+++ b/README.md
@@ -29,4 +29,6 @@ Instructions for adding a new Entity Framework database migration:
 
    `dotnet ef migrations add NAME_OF_MIGRATION --msbuildprojectextensionspath ..\artifacts\FMS.Infrastructure\obj\`
 
-   `TK's path: repos\FMS> dotnet ef migrations add NAME_OF_MIGRATION --msbuildprojectextensionspath ..\artifacts\FMS.Infrastructure\obj\`
+Example to show exact path:
+
+   `TK's path: D:\source\repos\FMS\fms.infrastructure> dotnet ef migrations add NAME_OF_MIGRATION --msbuildprojectextensionspath ..\artifacts\FMS.Infrastructure\obj\`


### PR DESCRIPTION
TaxID and other information in the "Parcel" table of the existing AccessDB will be migrated into the "Location Description" of the Facility in FMS. The old field data (Parcel Name, Acres, TaxID) will be separated with the "^" symbol. This eliminates the need for the TaxID field. 