### PR TITLE
Permissions - Add-Edit Facilities as per UAT notes

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilitySpec.cs
+++ b/FMS.Domain/Dto/Facility/FacilitySpec.cs
@@ -18,7 +18,7 @@ namespace FMS.Domain.Dto
         [Display(Name = "Include deleted records")]
         public bool ShowDeleted { get; set; }
 
-        [Display(Name = "Show Pending Only CheckBox")]
+        [Display(Name = "Show Pending Only")]
         public bool ShowPendingOnly { get; set; }
 
         [Display(Name = "County")]

--- a/FMS.Domain/Repositories/IFacilityRepository.cs
+++ b/FMS.Domain/Repositories/IFacilityRepository.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using FMS.Domain.Dto;
 using FMS.Domain.Dto.PaginatedList;
+using FMS.Domain.Entities;
 
 namespace FMS.Domain.Repositories
 {
@@ -22,6 +23,7 @@ namespace FMS.Domain.Repositories
         Task DeleteFacilityAsync(Guid id);
         Task UndeleteFacilityAsync(Guid id);
         Task<bool> FacilityNumberExists(string facilityNumber, Guid? ignoreId = null);
+        Task<bool> DuplicateFacilityNumberExists(string newFacilityNumber, Guid oldFacilityId, Guid facilityTypeId);
         Task<bool> FileLabelExists(string fileLabel);
         Task<int> GetNextSequenceForCountyAsync(int countyId);
 

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -395,6 +395,11 @@ namespace FMS.Infrastructure.Repositories
                 e.FacilityNumber == facilityNumber
                 && (!ignoreId.HasValue || e.Id != ignoreId.Value));
 
+        public Task<bool> DuplicateFacilityNumberExists(string newFacilityNumber, Guid oldFacilityId, Guid facilityTypeId) => _context.Facilities.AnyAsync(
+            e => e.FacilityNumber == newFacilityNumber 
+            && e.Id != oldFacilityId 
+            && e.FacilityTypeId == facilityTypeId);
+
         public Task<bool> FileLabelExists(string fileLabel) =>
             _context.Files.AnyAsync(e => e.FileLabel == fileLabel);
 

--- a/FMS/Helpers/ExportHelper.cs
+++ b/FMS/Helpers/ExportHelper.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ClosedXML.Excel;
+using DocumentFormat.OpenXml.Bibliography;
+using ExcelNumberFormat;
 using FMS.Domain.Dto;
 using FMS.Domain.Services;
 using Spire.Pdf;
@@ -13,20 +15,37 @@ namespace FMS
 {
     public static class ExportHelper
     {
+        public enum ReportType
+        {
+            Normal,
+            Pending,
+            Map
+        }
+
         /// <summary>
         /// Takes in a list of generic T, input it into the XLWorkbook, convert it to a byte array.
         /// </summary>
         /// <param name="list">A list of FacilityDetailDtoScalar or FacilityMapSummaryDtoScalar</param>
         /// <typeparam name="T">FacilityDetailDtoScalar or FacilityMapSummaryDtoScalar</typeparam>
         /// <returns>A byte array to use in File()</returns>
-        public static byte[] ExportExcelAsByteArray<T>(this IEnumerable<T> list)
+        public static byte[] ExportExcelAsByteArray<T>(this IEnumerable<T> list, ReportType reportType)
         {
             var ms = new MemoryStream();
             var wb = new XLWorkbook();
             var ws = wb.AddWorksheet("Search_Results");
             // insert the enumerable data
             ws.Cell(1, 1).InsertTable(list);
-            ws.Columns().AdjustToContents(1, 100);
+            ws.Columns().AdjustToContents(1, 10000);
+            if (reportType == ReportType.Pending)
+            {
+                ws.Column("E").Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.DateTime.DayMonthYear4WithSlashes;
+            }
+            if (reportType == ReportType.Normal)
+            {
+                ws.Column(16).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.DateTime.DayMonthYear4WithSlashes;
+                ws.Column(17).Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.DateTime.DayMonthYear4WithSlashes;
+            }
+
             wb.SaveAs(ms);
             return ms.ToArray();
         }

--- a/FMS/Pages/Facilities/Add.cshtml
+++ b/FMS/Pages/Facilities/Add.cshtml
@@ -21,7 +21,7 @@
         <div class="mb-3 row">
             <div class="col-md-4">
                 <label asp-for="Facility.FileLabel">File Label <span class="text-danger">*</span></label>
-                <input asp-for="Facility.FileLabel" class="form-control" aria-describedby="FileIdHelpBlock" disabled="@(Model.ConfirmFacility || Model.IsNotSiteMaintenanceUser)" />
+                <input asp-for="Facility.FileLabel" class="form-control" aria-describedby="FileIdHelpBlock" disabled="@Model.ConfirmFacility" readonly="@Model.IsNotSiteMaintenanceUser)" />
                 <span asp-validation-for="Facility.FileLabel" class="text-danger"></span>
                 <small id="FileIdHelpBlock" class="form-text text-muted">Enter an existing File or leave blank to create a new File.</small>
             </div>

--- a/FMS/Pages/Facilities/Add.cshtml
+++ b/FMS/Pages/Facilities/Add.cshtml
@@ -21,7 +21,7 @@
         <div class="mb-3 row">
             <div class="col-md-4">
                 <label asp-for="Facility.FileLabel">File Label <span class="text-danger">*</span></label>
-                <input asp-for="Facility.FileLabel" class="form-control" aria-describedby="FileIdHelpBlock" disabled="@Model.ConfirmFacility" />
+                <input asp-for="Facility.FileLabel" class="form-control" aria-describedby="FileIdHelpBlock" disabled="@(Model.ConfirmFacility || Model.IsNotSiteMaintenanceUser)" />
                 <span asp-validation-for="Facility.FileLabel" class="text-danger"></span>
                 <small id="FileIdHelpBlock" class="form-text text-muted">Enter an existing File or leave blank to create a new File.</small>
             </div>

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -285,7 +285,7 @@
         }
 
         @if (Model.FacilityDetail.Active &&
-       (User.IsInRole(UserRoles.FileCreator) || User.IsInRole(UserRoles.FileEditor)))
+       (User.IsInRole(UserRoles.FileCreator) || User.IsInRole(UserRoles.FileEditor) || User.IsInRole(UserRoles.SiteMaintenance)))
         {
             <div class="container bg-light-subtle pt-3 mt-5 rounded-3">
                 <h3 class="h5">Add a Retention Record</h3>

--- a/FMS/Pages/Facilities/Edit.cshtml
+++ b/FMS/Pages/Facilities/Edit.cshtml
@@ -25,7 +25,7 @@
         <div class="mb-3 row">
             <div class="col-md-4">
                 <label asp-for="Facility.FileLabel">File Label <span class="text-danger">*</span></label>
-                <input asp-for="Facility.FileLabel" class="form-control" aria-describedby="FileIdHelpBlock" readonly="@Model.IsNotSiteMaintenanceUser" disabled="@Model.ConfirmFacility" />
+                <input asp-for="Facility.FileLabel" class="form-control" aria-describedby="FileIdHelpBlock" readonly="true" />
                 <span asp-validation-for="Facility.FileLabel" class="text-danger"></span>
                 <small id="FileIdHelpBlock" class="form-text text-muted">Leave blank to create new or add to existing File</small>
             </div>

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -96,6 +96,8 @@ namespace FMS.Pages.Facilities
                 return Page();
             }
 
+            IsNotSiteMaintenanceUser = !User.IsInRole(UserRoles.SiteMaintenance);
+
             Facility.TrimAll();
             
             // Reload facility and see if it has been deleted by another user
@@ -138,21 +140,24 @@ namespace FMS.Pages.Facilities
                 return Page();
             }
 
-            var mapSearchSpec = new FacilityMapSpec
+            if (!IsNotSiteMaintenanceUser)
             {
-                Latitude = Facility.Latitude,
-                Longitude = Facility.Longitude,
-                Radius = 0.5m,
-            };
+                var mapSearchSpec = new FacilityMapSpec
+                {
+                    Latitude = Facility.Latitude,
+                    Longitude = Facility.Longitude,
+                    Radius = 0.5m,
+                };
 
-            NearbyFacilities = await _repository.GetFacilityListAsync(mapSearchSpec);
+                NearbyFacilities = await _repository.GetFacilityListAsync(mapSearchSpec);
 
-            if (NearbyFacilities != null && NearbyFacilities.Count > 0)
-            {
-                ConfirmedFacilityFileLabel = Facility.FileLabel.IsNullOrEmpty() ? "Choose" : Facility.FileLabel;  
-                await PopulateSelectsAsync();
-                ConfirmFacility = true;
-                return Page();
+                if (NearbyFacilities != null && NearbyFacilities.Count > 0)
+                {
+                    ConfirmedFacilityFileLabel = Facility.FileLabel.IsNullOrEmpty() ? "Choose" : Facility.FileLabel;
+                    await PopulateSelectsAsync();
+                    ConfirmFacility = true;
+                    return Page();
+                }
             }
 
             try
@@ -183,8 +188,9 @@ namespace FMS.Pages.Facilities
                 await PopulateSelectsAsync();
                 return Page();
             }
+            IsNotSiteMaintenanceUser = !User.IsInRole(UserRoles.SiteMaintenance);
 
-            if (ConfirmedFacilityFileLabel == "Choose")
+            if (ConfirmedFacilityFileLabel == "Choose" || !IsNotSiteMaintenanceUser)
             {
                 var mapSearchSpec = new FacilityMapSpec
                 {
@@ -235,7 +241,7 @@ namespace FMS.Pages.Facilities
                 return Page();
             }
 
-            Facility.FacilityTypeName = await _repositoryType.GetFacilityTypeNameAsync(Facility.FacilityTypeId);
+            //Facility.FacilityTypeName = await _repositoryType.GetFacilityTypeNameAsync(Facility.FacilityTypeId);
 
             await _repository.UpdateFacilityAsync(Id, Facility);
 

--- a/FMS/Pages/Facilities/Index.cshtml
+++ b/FMS/Pages/Facilities/Index.cshtml
@@ -104,7 +104,7 @@
             </div>
         </div>
         <div class="mb-3 row">
-            @if (User.IsInRole(UserRoles.FileEditor))
+            @if (User.IsInRole(UserRoles.FileEditor) || User.IsInRole(UserRoles.SiteMaintenance))
             {
                 <div class="col-md-3">
                     <div class="form-check">

--- a/FMS/Pages/Facilities/Index.cshtml
+++ b/FMS/Pages/Facilities/Index.cshtml
@@ -169,7 +169,7 @@
                                     Excel Export
                                 </button>
                                 <button id="PendingButton" asp-page-handler="PendingButton"
-                                        class="btn btn-sm btn-outline-primary mb-1 @(Model.Spec.ShowPendingOnly ? "" : "d-none")">
+                                        class="btn btn-sm btn-outline-primary mb-1 @(Model.ShowPendingOnlyCheckBox ? "" : "d-none")">
                                     Pending Report
                                 </button>
                                 <button id="DownloadRetentionRecords" asp-page-handler="DownloadRetentionRecords"

--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -86,7 +86,7 @@ namespace FMS.Pages.Facilities
             // "FacilityReportList" Detailed Facility List to go to a report
             IReadOnlyList<FacilityDetailDto> facilityReportList = await _repository.GetFacilityDetailListAsync(Spec);
             var facilityDetailList = from p in facilityReportList select new FacilityDetailDtoScalar(p);
-            return File(facilityDetailList.ExportExcelAsByteArray(), "application/vnd.ms-excel", fileName);
+            return File(facilityDetailList.ExportExcelAsByteArray(ExportHelper.ReportType.Normal), "application/vnd.ms-excel", fileName);
         }
 
         public async Task<IActionResult> OnPostPendingButtonAsync()
@@ -95,7 +95,7 @@ namespace FMS.Pages.Facilities
             // "FacilityPendingList" Detailed Facility List to go to a report
             IReadOnlyList<FacilityDetailDto> facilityReportList = await _repository.GetFacilityDetailListAsync(Spec);
             var facilityDetailList = from p in facilityReportList select new FacilityPendingDtoScalar(p);
-            return File(facilityDetailList.ExportExcelAsByteArray(), "application/vnd.ms-excel", fileName);
+            return File(facilityDetailList.ExportExcelAsByteArray(ExportHelper.ReportType.Pending), "application/vnd.ms-excel", fileName);
         }
 
         public async Task<IActionResult> OnPostDownloadRetentionRecordsAsync()

--- a/FMS/Pages/Facilities/Map.cshtml.cs
+++ b/FMS/Pages/Facilities/Map.cshtml.cs
@@ -135,7 +135,7 @@ namespace FMS.Pages.Facilities
             var fileName = $"FMS_Map_export{DateTime.Now:yyyy-MM-dd.HH-mm-ss.FFF}.xlsx";
             IReadOnlyList<FacilityMapSummaryDto> facilityMapSummaries = await _repository.GetFacilityListAsync(ExportSpec);
             var facilityMapDetail = from p in facilityMapSummaries select new FacilityMapSummaryDtoScalar(p);
-            return File(facilityMapDetail.ExportExcelAsByteArray(), "application/vnd.ms.excel", fileName);
+            return File(facilityMapDetail.ExportExcelAsByteArray(ExportHelper.ReportType.Map), "application/vnd.ms.excel", fileName);
         }
 
         private async Task PopulateSelectsAsync()

--- a/FMS/Pages/Users/Details.cshtml
+++ b/FMS/Pages/Users/Details.cshtml
@@ -1,10 +1,15 @@
 @page "{id:Guid?}"
 @using FMS.Domain.Entities.Users
 @model FMS.Pages.Users.DetailsModel
+
+@section Scripts {
+    <script src="~/js/formDetails.js"></script>
+}
+
 @{
     ViewData["Title"] = "User Profile: " + Model.DisplayName;
 }
-<script src="~/js/formDetails.js"></script>
+
 <h1>FMS User Profile</h1>
 <hr />
 <partial name="_AlertPartial" for="Message" />

--- a/FMS/wwwroot/js/formSearch.js
+++ b/FMS/wwwroot/js/formSearch.js
@@ -21,7 +21,8 @@ $(document).ready(function formSearch() {
         } else {
             $("#RNBlock").addClass("d-none");
             $("#DownloadRetentionRecords").removeClass("d-none");
-            $("#Spec_ShowPendingOnly").prop("checked",false)
+            $("#Spec_ShowPendingOnly").prop("checked", false)
+            $("#PendingButton").addClass("d-none");
         }
     });
     $("#cbPending").click(function () {


### PR DESCRIPTION
Change Permissions as follows:

- File Label update option should only be provided to Facility Editor when there is not a File Label assigned. If there is already a File Label assigned, Site Maintenance role should be only role that sees File Label update option. 
- Should not be able to duplicate Notification or HSI Facility Nos. See screenshot below. Logic appears to prevent this on Add Facility screen, but not on Edit screen.