### PR TITLE
Added SortBy Received Date to Pending query

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilitySort.cs
+++ b/FMS.Domain/Dto/Facility/FacilitySort.cs
@@ -10,5 +10,7 @@
         FileLabelDesc,
         Name,
         NameDesc,
+        RNDateReceived,
+        RNDateReceivedDesc,
     }
 }

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -95,6 +95,10 @@ namespace FMS.Infrastructure.Repositories
                     .ThenBy(e => e.Name),
                 FacilitySort.FileLabelDesc => included.OrderByDescending(e => e.File.FileLabel)
                     .ThenByDescending(e => e.Name),
+                FacilitySort.RNDateReceived => included.OrderBy(e => e.RNDateReceived)
+                    .ThenBy(e => e.FacilityNumber),
+                FacilitySort.RNDateReceivedDesc => included.OrderByDescending(e => e.RNDateReceived)
+                    .ThenByDescending(e => e.FacilityNumber),
                 // FacilitySort.Name
                 _ => included.OrderBy(e => e.Name)
                     .ThenBy(e => e.FacilityNumber)

--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -69,7 +69,9 @@ namespace FMS.Pages.Facilities
 
         public async Task<IActionResult> OnGetSearchAsync(FacilitySpec spec, [FromQuery] int p = 1)
         {
-            // Get the list of facilities matching the "Spec" criteria
+            // Get the list of facilities matching the "Spec" criteria.
+            // Sort by Received Date for Pending Release Notifications
+            spec.SortBy = spec.ShowPendingOnly ? FacilitySort.RNDateReceivedDesc : FacilitySort.Name;
             FacilityList = await _repository.GetFacilityPaginatedListAsync(spec, p, GlobalConstants.PageSize);
             Spec = spec;
             
@@ -93,6 +95,7 @@ namespace FMS.Pages.Facilities
         {
             var fileName = $"FMS_PendingRN_export_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
             // "FacilityPendingList" Detailed Facility List to go to a report
+            // sorted by Received Date
             IReadOnlyList<FacilityDetailDto> facilityReportList = await _repository.GetFacilityDetailListAsync(Spec);
             var facilityDetailList = from p in facilityReportList select new FacilityPendingDtoScalar(p);
             return File(facilityDetailList.ExportExcelAsByteArray(ExportHelper.ReportType.Pending), "application/vnd.ms-excel", fileName);


### PR DESCRIPTION
Added criteria to sort by Received Date ascending and descending, for Pending RN query and Report.

When exported to Excel, the Date fields are properly Ordered in descending order by Received Date.
However, Even though the Dates exported to Excel are in Date Format, Excel still seems them as Text. So, Sorting them by Received Date after import into Excel is not possible, because Excel sees the Date Fields as Text Values for some reason. I don't think there is another way to export this report to make Excel Treat these Date fields any differently.

Closes issue https://github.com/gaepdit/FMS/issues/384