### PR TITLE
Fix Null File Label exception

### DIFF
--- a/FMS.Domain/Dto/Cabinet/CabinetExtensions.cs
+++ b/FMS.Domain/Dto/Cabinet/CabinetExtensions.cs
@@ -8,15 +8,12 @@ namespace FMS.Domain.Dto
 {
     public static class CabinetExtensions
     {
-        public static List<string> GetCabinetsForFile(this IEnumerable<CabinetSummaryDto> cabinets, string fileLabel, bool testValidity = true)
+        public static List<string> GetCabinetsForFile(this IEnumerable<CabinetSummaryDto> cabinets, string fileLabel)
         {
-            if (testValidity) 
+            Prevent.NullOrEmpty(fileLabel, nameof(fileLabel));
+            if (!File.IsValidFileLabelFormat(fileLabel))
             {
-                Prevent.NullOrEmpty(fileLabel, nameof(fileLabel));
-                if (!File.IsValidFileLabelFormat(fileLabel))
-                {
-                    throw new ArgumentException($"File label '{fileLabel}' is invalid.", nameof(fileLabel));
-                }
+                throw new ArgumentException($"File label '{fileLabel}' is invalid.", nameof(fileLabel));
             }
 
             return cabinets.Where(e =>

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -133,9 +133,10 @@ namespace FMS.Infrastructure.Repositories
             var cabinets = await _context.GetCabinetListAsync(false);
             foreach (var item in items)
             {
-                bool test = item.FacilityType.Name != "RN" || !item.FileLabel.IsNullOrEmpty();
-
-                item.Cabinets = cabinets.GetCabinetsForFile(item.FileLabel, test);
+                if (!item.FileLabel.IsNullOrEmpty())
+                {
+                    item.Cabinets = cabinets.GetCabinetsForFile(item.FileLabel);
+                }
             }
 
             var totalCount = await queried.CountAsync();


### PR DESCRIPTION
Fix bug when File Label is null or empty. Test corrected before trying to fetch Cabinets and files for Null File Label.

closes #394 