### PR TITLE
Correct Sorting for all types

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilitySpec.cs
+++ b/FMS.Domain/Dto/Facility/FacilitySpec.cs
@@ -9,6 +9,8 @@ namespace FMS.Domain.Dto
     {
         public FacilitySort SortBy { get; set; } = FacilitySort.Name;
 
+        public bool FirstPass { get; set; } = true;
+
         [Display(Name = "Facility Number")]
         public string FacilityNumber { get; set; }
 
@@ -115,6 +117,7 @@ namespace FMS.Domain.Dto
                 {nameof(PostalCode), PostalCode},
                 {nameof(State), State},
                 {nameof(ShowPendingOnly), ShowPendingOnly.ToString()},
+                {nameof(FirstPass), FirstPass.ToString()},
             };
     }
 }

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -169,7 +169,6 @@ namespace FMS.Infrastructure.Repositories
                 {
                     item.Cabinets = cabinets.GetCabinetsForFile(item.FileLabel);
                 }
-
             }
 
             return items;

--- a/FMS/Pages/Facilities/Index.cshtml
+++ b/FMS/Pages/Facilities/Index.cshtml
@@ -164,6 +164,7 @@
                                 <input type="hidden" asp-for="Spec.ShowDeleted" />
                                 <input type="hidden" asp-for="Spec.ShowPendingOnly" />
                                 <input type="hidden" asp-for="Spec.SortBy" />
+                                <input type="hidden" asp-for="Spec.FirstPass" />
                                 <button id="ExportButton" asp-page-handler="ExportButton"
                                         class="btn btn-sm btn-outline-primary mb-1">
                                     Excel Export

--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -39,11 +39,6 @@ namespace FMS.Pages.Facilities
         [BindProperty]
         public bool ShowPendingOnlyCheckBox { get; private set; }
 
-        // First time through search will sort by name,
-        // but for pending RNs will sort by ReceivedDate
-        //[BindProperty]
-       
-
         // Select Lists
         public SelectList Counties => new(Data.Counties, "Id", "Name");
         public SelectList States => new(Data.States);
@@ -67,6 +62,8 @@ namespace FMS.Pages.Facilities
 
         public async Task<IActionResult> OnGetAsync()
         {
+            // First time through search will sort by name,
+            // but for pending RNs will sort by ReceivedDate
             Spec = new FacilitySpec() { FirstPass = true };
             await PopulateSelectsAsync();
             return Page();


### PR DESCRIPTION
This commit fixes the sorting of all types and ensures consistency.

closes #411 