### PR TITLE
IsNullOrEmpty errors corrected

### DIFF
--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -46,7 +46,7 @@ namespace FMS.Infrastructure.Repositories
 
             var facilityDetail = new FacilityDetailDto(facility);
 
-            if (!facilityDetail.FileLabel.IsNullOrEmpty())
+            if (!string.IsNullOrEmpty(facilityDetail.FileLabel))
             {
                 facilityDetail.Cabinets = (await _context.GetCabinetListAsync(false))
                 .GetCabinetsForFile(facilityDetail.FileLabel);
@@ -133,7 +133,7 @@ namespace FMS.Infrastructure.Repositories
             var cabinets = await _context.GetCabinetListAsync(false);
             foreach (var item in items)
             {
-                if (!item.FileLabel.IsNullOrEmpty())
+                if (!string.IsNullOrEmpty(item.FileLabel))
                 {
                     item.Cabinets = cabinets.GetCabinetsForFile(item.FileLabel);
                 }
@@ -165,7 +165,7 @@ namespace FMS.Infrastructure.Repositories
 
             foreach (var item in items)
             {
-                if (!item.FileLabel.IsNullOrEmpty())
+                if (!string.IsNullOrEmpty(item.FileLabel))
                 {
                     item.Cabinets = cabinets.GetCabinetsForFile(item.FileLabel);
                 }
@@ -225,7 +225,7 @@ namespace FMS.Infrastructure.Repositories
                 throw new ArgumentException($"Facility Number '{newFacility.FacilityNumber}' already exists.");
             }
 
-            if (newFacility.FacilityNumber.IsNullOrEmpty() && newFacility.FacilityTypeName == "RN")
+            if (string.IsNullOrEmpty(newFacility.FacilityNumber) && newFacility.FacilityTypeName == "RN")
             {
                 newFacility.FacilityNumber = await CreateRNFacilityNumberInternalAsync();
             }

--- a/FMS/Helpers/FormValidationHelper.cs
+++ b/FMS/Helpers/FormValidationHelper.cs
@@ -72,7 +72,7 @@ namespace FMS.Helpers
                     errCol.Add(new ModelError(string.Concat("Facility.FacilityNumber", "^", "Facility Number must be in the form 'RNdddd'")));
                 }
                 // Check HSI Number 
-                if (!facility.HSInumber.IsNullOrEmpty() && !hsiRegex.IsMatch(facility.HSInumber))
+                if (!string.IsNullOrEmpty(facility.HSInumber) && !hsiRegex.IsMatch(facility.HSInumber))
                 {
                     errCol.Add(new ModelError(string.Concat("Facility.HSInumber", "^", "HSI Number must be 5 digits Only.")));
                 }
@@ -80,14 +80,14 @@ namespace FMS.Helpers
             else if(facility.FacilityTypeName == "HSI")
             {
                 // Check Facility Number 
-                if (!facility.FacilityNumber.IsNullOrEmpty() && !hsiRegex.IsMatch(facility.FacilityNumber))
+                if (!string.IsNullOrEmpty(facility.FacilityNumber) && !hsiRegex.IsMatch(facility.FacilityNumber))
                 {
                     errCol.Add(new ModelError(string.Concat("Facility.FacilityNumber", "^", "HSI Number must be 5 digits Only.")));
                 }
             }
             else
             {
-                if (facility.FacilityNumber.IsNullOrEmpty())
+                if (string.IsNullOrEmpty(facility.FacilityNumber))
                 {
                     errCol.Add(new ModelError(string.Concat("Facility.FacilityNumber", "^", "Facility Number must not be blank")));
                 }

--- a/FMS/Helpers/URLHelper.cs
+++ b/FMS/Helpers/URLHelper.cs
@@ -7,21 +7,21 @@ namespace FMS.Helpers
     {
         public static string GetHSIFolderLink(string hsiNumber)
         {
-            return hsiNumber.IsNullOrEmpty()
+            return string.IsNullOrEmpty(hsiNumber)
                 ? null 
                 : string.Concat(GlobalConstants.HSIFolder, hsiNumber);
         }
 
         public static string GetNotificationFolderLink(string notificationId)
         {
-            return notificationId.IsNullOrEmpty()
+            return string.IsNullOrEmpty(notificationId)
                 ? null
                 : string.Concat(GlobalConstants.NotificationFolder, notificationId.Substring(2));
         }
 
         public static string GetPendingNotificationFolderLink(string notificationId)
         {
-            return notificationId.IsNullOrEmpty()
+            return string.IsNullOrEmpty(notificationId)
                 ? null
                 : string.Concat(GlobalConstants.PendingNotificationFolder, notificationId.Substring(2));
         }

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -127,7 +127,7 @@ namespace FMS.Pages.Facilities
 
             if (NearbyFacilities != null && NearbyFacilities.Count > 0)
             {
-                ConfirmedFacilityFileLabel = Facility.FileLabel.IsNullOrEmpty() ? "Choose" : Facility.FileLabel;
+                ConfirmedFacilityFileLabel = string.IsNullOrEmpty(Facility.FileLabel) ? "Choose" : Facility.FileLabel;
                 await PopulateSelectsAsync();
                 ConfirmFacility = true;
                 return Page();
@@ -160,7 +160,7 @@ namespace FMS.Pages.Facilities
 
                 if (NearbyFacilities != null && NearbyFacilities.Count > 0)
                 {
-                    ConfirmedFacilityFileLabel = Facility.FileLabel.IsNullOrEmpty() ? "Choose" : Facility.FileLabel;
+                    ConfirmedFacilityFileLabel = string.IsNullOrEmpty(Facility.FileLabel) ? "Choose" : Facility.FileLabel;
                     await PopulateSelectsAsync();
                     ConfirmFacility = true;
                     return Page();

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -146,7 +146,7 @@ namespace FMS.Pages.Facilities
                 return Page();
             }
 
-            if (!IsNotSiteMaintenanceUser || Facility.FileLabel.IsNullOrEmpty())
+            if (!IsNotSiteMaintenanceUser || string.IsNullOrEmpty(Facility.FileLabel))
             {
                 var mapSearchSpec = new FacilityMapSpec
                 {
@@ -159,7 +159,7 @@ namespace FMS.Pages.Facilities
 
                 if (NearbyFacilities != null && NearbyFacilities.Count > 0)
                 {
-                    ConfirmedFacilityFileLabel = Facility.FileLabel.IsNullOrEmpty() ? "Choose" : Facility.FileLabel;
+                    ConfirmedFacilityFileLabel = string.IsNullOrEmpty(Facility.FileLabel) ? "Choose" : Facility.FileLabel;
                     await PopulateSelectsAsync();
                     ConfirmFacility = true;
                     return Page();
@@ -208,7 +208,7 @@ namespace FMS.Pages.Facilities
 
                 if (NearbyFacilities != null && NearbyFacilities.Count > 0)
                 {
-                    ConfirmedFacilityFileLabel = Facility.FileLabel.IsNullOrEmpty() ? "Choose" : Facility.FileLabel;
+                    ConfirmedFacilityFileLabel = string.IsNullOrEmpty(Facility.FileLabel) ? "Choose" : Facility.FileLabel;
                     await PopulateSelectsAsync();
                     ConfirmFacility = true;
                     return Page();


### PR DESCRIPTION
Added Argument to all methods without an argument. 
IsNullOrEmpty now cannot be used unless it is in the form:
"string.IsNullOrEmpty(argument)"
