### PR TITLE
Remove the security.txt file

### DIFF
--- a/FMS/wwwroot/.well-known/security.txt
+++ b/FMS/wwwroot/.well-known/security.txt
@@ -1,5 +1,0 @@
-Contact: mailto:support@gaepd.zendesk.com
-Expires: 2024-10-01T00:00:00.000Z
-Preferred-Languages: en
-Policy: https://github.com/gaepdit/.github/blob/main/SECURITY.md
-


### PR DESCRIPTION
This PR removes the `security.txt` file.

Instead of hosting separate copies of the file with each application that then have to be individually updated every year, our new approach will be to redirect the `.well-known` location to a centrally managed file instead. This will make future updates easier.

The redirect will be handled in the `web.config` file. I'll take care of updating those on the web servers and in the "app-config" repo.

I branched off `main` instead of `Dev` because this changes no code or functionality and should be simple to deploy. Also, deploying this is low priority since the `web.config` redirect will take precedence whether or not this file exists on the server.

See https://github.com/gaepdit/EPD-IT/issues/148 for background.