### PR TITLE
Migrate to AwesomeAssertions and update config

### DIFF
--- a/.sonarlint/FMS.json
+++ b/.sonarlint/FMS.json
@@ -1,4 +1,5 @@
 {
-  "SonarCloudOrganization": "gaepdit",
-  "ProjectKey": "gaepdit_FMS"
+    "sonarCloudOrganization": "gaepdit",
+    "projectKey": "gaepdit_FMS",
+    "region": "EU"
 }

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="AwesomeAssertions" Version="8.0.1" />
+    <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="ClosedXML" Version="0.104.2" />
     <PackageVersion Include="Dapper" Version="2.1.35" />
     <PackageVersion Include="EfCore.TestSupport" Version="9.0.0" />
@@ -27,7 +29,6 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="[7.0.0,8.0)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,31 +6,30 @@
     <PackageVersion Include="AwesomeAssertions" Version="8.0.1" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="ClosedXML" Version="0.104.2" />
-    <PackageVersion Include="Dapper" Version="2.1.35" />
+    <PackageVersion Include="Dapper" Version="2.1.66" />
     <PackageVersion Include="EfCore.TestSupport" Version="9.0.0" />
     <PackageVersion Include="FluentMermaid" Version="0.1.0" />
     <PackageVersion Include="FreeSpire.PDF" Version="10.2.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.433" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="9.0.1" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="3.6.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="9.0.2" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="3.7.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-    <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="11.2.1" />
+    <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="11.2.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200" />
-    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.6.0.109712" />
+    <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>
 </Project>

--- a/FMS/FMS.csproj
+++ b/FMS/FMS.csproj
@@ -18,7 +18,6 @@
     <PackageReference Include="ClosedXML" />
     <PackageReference Include="FreeSpire.PDF" />
     <PackageReference Include="JetBrains.Annotations" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />

--- a/tests/FMS.App.Tests/FMS.App.Tests.csproj
+++ b/tests/FMS.App.Tests/FMS.App.Tests.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions"/>
+    <PackageReference Include="AwesomeAssertions.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp">

--- a/tests/FMS.App.Tests/Facilities/FacilityAddTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityAddTests.cs
@@ -1,14 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using FluentAssertions;
 using FMS.Domain.Dto;
 using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
 using NSubstitute;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
 
 namespace FMS.App.Tests.Facilities
 {
@@ -20,12 +24,18 @@ namespace FMS.App.Tests.Facilities
             var mockRepo = Substitute.For<IFacilityRepository>();
             var mockType = Substitute.For<IFacilityTypeRepository>();
             var mockSelectListHelper = Substitute.For<ISelectListHelper>();
-            var pageModel = new AddModel(mockRepo, mockType, mockSelectListHelper);
+
+            // Mock user & page context
+            var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new GenericIdentity("Name")) };
+            var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor());
+            var pageContext = new PageContext(actionContext);
+
+            var pageModel = new AddModel(mockRepo, mockType, mockSelectListHelper) { PageContext = pageContext };
 
             var result = await pageModel.OnGetAsync();
 
             result.Should().BeOfType<PageResult>();
-            pageModel.Facility.Should().BeEquivalentTo(new FacilityCreateDto {State = "Georgia"});
+            pageModel.Facility.Should().BeEquivalentTo(new FacilityCreateDto { State = "Georgia" });
         }
 
         [Test]
@@ -41,7 +51,8 @@ namespace FMS.App.Tests.Facilities
             var mockSelectListHelper = Substitute.For<ISelectListHelper>();
             var pageModel = new AddModel(mockRepo, mockType, mockSelectListHelper)
             {
-                Facility = new FacilityCreateDto { State = "Georgia", Latitude = 0, Longitude = 0 },
+                Facility = new FacilityCreateDto
+                    { State = "Georgia", Latitude = 31, Longitude = -81, FacilityNumber = "a" },
             };
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
@@ -73,7 +84,8 @@ namespace FMS.App.Tests.Facilities
             var mockSelectListHelper = Substitute.For<ISelectListHelper>();
             var pageModel = new AddModel(mockRepo, mockType, mockSelectListHelper)
             {
-                Facility = new FacilityCreateDto { State = "Georgia", Latitude = 0, Longitude = 0 },
+                Facility = new FacilityCreateDto
+                    { State = "Georgia", Latitude = 31, Longitude = -81, FacilityNumber = "a" },
             };
 
             var result = await pageModel.OnPostAsync().ConfigureAwait(false);
@@ -96,7 +108,8 @@ namespace FMS.App.Tests.Facilities
             var mockSelectListHelper = Substitute.For<ISelectListHelper>();
             var pageModel = new AddModel(mockRepo, mockType, mockSelectListHelper)
             {
-                Facility = new FacilityCreateDto {State = "Georgia"}
+                Facility = new FacilityCreateDto
+                    { State = "Georgia", Latitude = 31, Longitude = -81, FacilityNumber = "a" },
             };
 
             var result = await pageModel.OnPostConfirmAsync().ConfigureAwait(false);

--- a/tests/FMS.App.Tests/Facilities/FacilityEditTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityEditTests.cs
@@ -1,14 +1,18 @@
-using System;
-using System.Threading.Tasks;
 using FluentAssertions;
 using FMS.Domain.Dto;
 using FMS.Domain.Repositories;
 using FMS.Pages.Facilities;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Routing;
 using NSubstitute;
-using TestHelpers;
 using NUnit.Framework;
+using System;
+using System.Security.Claims;
+using System.Security.Principal;
+using System.Threading.Tasks;
+using TestHelpers;
 
 namespace FMS.App.Tests.Facilities
 {
@@ -25,7 +29,13 @@ namespace FMS.App.Tests.Facilities
             mockRepo.GetFacilityAsync(Arg.Any<Guid>()).Returns(facility);
 
             var mockSelectListHelper = Substitute.For<ISelectListHelper>();
-            var pageModel = new EditModel(mockRepo, mockType, mockSelectListHelper);
+
+            // Mock user & page context
+            var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new GenericIdentity("Name")) };
+            var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor());
+            var pageContext = new PageContext(actionContext);
+
+            var pageModel = new EditModel(mockRepo, mockType, mockSelectListHelper) { PageContext = pageContext };
 
             var result = await pageModel.OnGetAsync(facility.Id);
 
@@ -74,10 +84,17 @@ namespace FMS.App.Tests.Facilities
             var mockType = Substitute.For<IFacilityTypeRepository>();
 
             var mockSelectListHelper = Substitute.For<ISelectListHelper>();
+
+            // Mock user & page context
+            var httpContext = new DefaultHttpContext { User = new ClaimsPrincipal(new GenericIdentity("Name")) };
+            var actionContext = new ActionContext(httpContext, new RouteData(), new PageActionDescriptor());
+            var pageContext = new PageContext(actionContext);
+
             var pageModel = new EditModel(mockRepo, mockType, mockSelectListHelper)
             {
                 Id = id,
-                Facility = new FacilityEditDto()
+                Facility = new FacilityEditDto { Latitude = 31, Longitude = -81, FacilityNumber = "a" },
+                PageContext = pageContext,
             };
 
             var result = await pageModel.OnPostAsync();

--- a/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
+++ b/tests/FMS.App.Tests/Helpers/GeoCoordHelperTests.cs
@@ -1,12 +1,10 @@
-﻿using FMS.Helpers;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 
 namespace FMS.App.Tests.Helpers
 {
     public class GeoCoordHelperTests
     {
-        [TestCase(0)]
         [TestCase(32)]
         public void ValidLat_ReturnsTrue_GiveValidLatitude(decimal lat)
         {
@@ -20,7 +18,6 @@ namespace FMS.App.Tests.Helpers
             GeoCoordHelper.ValidLat(lat).Should().BeFalse();
         }
 
-        [TestCase(0)]
         [TestCase(-82)]
         public void ValidLon_ReturnsTrue_GiveValidLongitude(decimal lng)
         {

--- a/tests/FMS.Domain.Tests/FMS.Domain.Tests.csproj
+++ b/tests/FMS.Domain.Tests/FMS.Domain.Tests.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions"/>
+    <PackageReference Include="AwesomeAssertions.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit.Analyzers">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
+++ b/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
@@ -6,7 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions"/>
+    <PackageReference Include="AwesomeAssertions.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit.Analyzers">


### PR DESCRIPTION
As I mentioned on Teams a while back, we need to migrate away from the FluentAssertions NuGet package for licensing reasons. AwesomeAssertions is a community-supported fork with an identical API, so the migration was simple. I also fixed some failing unit tests.