### PR TITLE
Limit Retention PDF request

### DIFF
--- a/FMS/Helpers/ExportHelper.cs
+++ b/FMS/Helpers/ExportHelper.cs
@@ -62,7 +62,7 @@ namespace FMS
         /// <returns>A byte array to use in File()</returns>
         public static byte[] ExportPdfAsByteArray(
             IEnumerable<RetentionRecordDetailDto> list, UserView currentUser, int maxCol=18,
-            string blankFilePath="./Helpers/BlankRequestForm.pdf", int freeTierLimit=10)
+            string blankFilePath="./Helpers/BlankRequestForm.pdf")
         {
             PdfDocument mainDoc = new();
             // break the list into chunks of 18 elements
@@ -74,9 +74,6 @@ namespace FMS
             {
                 PdfDocument currDocument = GeneratePdfPage(smallerList, currentUser, maxCol, blankFilePath);
                 pdfDocuments.Add(currDocument);
-                // limit for the free tier
-                if (pdfDocuments.Count >= freeTierLimit)
-                    break;
             }
             // add all of the pages to the main document
             foreach (var pdfDocument in pdfDocuments)

--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -116,6 +116,13 @@ namespace FMS.Pages.Facilities
             // "FacilityReportList" Detailed Retention Record List to export
             IEnumerable<RetentionRecordDetailDto> retentionRecordDetailList =
                 await _repository.GetRetentionRecordsListAsync(Spec);
+            if (retentionRecordDetailList.Count() > 180)
+            {
+                TempData?.SetDisplayMessage(Context.Danger, "You have requested " + retentionRecordDetailList.Count() + " Retention Records, which is over the 180 allowed! Please narrow search results to send to PDF creator.");
+                Message = TempData?.GetDisplayMessage();
+                await PopulateSelectsAsync();
+                return Page();
+            }
             return File(ExportHelper.ExportPdfAsByteArray(retentionRecordDetailList, currentUser),
                 "application/pdf", fileName);
         }

--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -8,6 +8,7 @@ using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -111,14 +112,15 @@ namespace FMS.Pages.Facilities
 
         public async Task<IActionResult> OnPostDownloadRetentionRecordsAsync()
         {
+            const int recordLimit = 162;
             var currentUser = await _userService.GetCurrentUserAsync();
             var fileName = $"FMS_Retention_Records_export_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.pdf";
             // "FacilityReportList" Detailed Retention Record List to export
             IEnumerable<RetentionRecordDetailDto> retentionRecordDetailList =
                 await _repository.GetRetentionRecordsListAsync(Spec);
-            if (retentionRecordDetailList.Count() > 180)
+            if (retentionRecordDetailList.Count() > recordLimit)
             {
-                TempData?.SetDisplayMessage(Context.Danger, "You have requested " + retentionRecordDetailList.Count() + " Retention Records, which is over the 180 allowed! Please narrow search results to send to PDF creator.");
+                TempData?.SetDisplayMessage(Context.Danger, "You have requested " + retentionRecordDetailList.Count() + " Retention Records, which is over the 162 allowed! Please narrow search results to send to PDF creator.");
                 Message = TempData?.GetDisplayMessage();
                 await PopulateSelectsAsync();
                 return Page();

--- a/FMS/wwwroot/js/formIndex.js
+++ b/FMS/wwwroot/js/formIndex.js
@@ -1,3 +1,3 @@
 ﻿$(document).ready(function formIndex() {
-    setTimeout(function () { $('.alert').alert('close') }, 6000)
+    setTimeout(function () { $('.alert').alert('close') }, 10000)
 });


### PR DESCRIPTION
Limit the number of retention records allowed to be exported to PDF. Free software only allows up to 10 pages. On our form, 18 records can be put on each page, so I limited the number allowed to be sent to PDF at 180 records. 