### PR TITLE
Enable retry on failure on the SQL Server DB

### DIFF
--- a/FMS/Startup.cs
+++ b/FMS/Startup.cs
@@ -34,7 +34,7 @@ namespace FMS
             // Configure database
             services.AddDbContext<FmsDbContext>(opts =>
                 opts.UseSqlServer(Configuration.GetConnectionString("DefaultConnection"),
-                    x => x.MigrationsAssembly("FMS.Infrastructure")));
+                    x => x.EnableRetryOnFailure().MigrationsAssembly("FMS.Infrastructure")));
 
             // Configure Identity
             services.AddIdentity<ApplicationUser, IdentityRole<Guid>>()


### PR DESCRIPTION
This enables automatically retrying DB commands in the event of transient failures. See [Connection Resiliency](https://learn.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency) for more info.