### PR TITLE
Adds Document Type entity

### DIFF
--- a/FMS.Domain/Dto/DocumentType/DocumentTypeCreateDto.cs
+++ b/FMS.Domain/Dto/DocumentType/DocumentTypeCreateDto.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using FMS.Domain.Entities;
+
+namespace FMS.Domain.Dto
+{
+    public class DocumentTypeCreateDto
+    {
+        [Display(Name = "Document Type")]
+        [Required(ErrorMessage = "Document Type Name is required.")]
+        public string Name { get; set; }
+    }
+}

--- a/FMS.Domain/Entities/DocumentType.cs
+++ b/FMS.Domain/Entities/DocumentType.cs
@@ -1,19 +1,22 @@
-﻿using FMS.Domain.Entities.Base;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FMS.Domain.Dto;
+using FMS.Domain.Entities.Base;
 
 namespace FMS.Domain.Entities
 {
-    public class FundingSource : BaseActiveNamedModel
+    public class DocumentType : BaseActiveNamedModel
     {
-        public FundingSource(FundingSourceCreateDto fundingSource)
+        public DocumentType(DocumentTypeCreateDto documentType)
         {
-            Name = fundingSource.Name;
+            Name = documentType.Name;
         }
+
+        public string Name { get; set; }
+
         public void TrimAll()
         {
             Name = Name?.Trim();


### PR DESCRIPTION
Adds the DocumentType entity and its corresponding create DTO. This allows managing different types of documents within the application. The DocumentType entity inherits from BaseActiveNamedModel and includes a name property. The create DTO includes validation for the name property.

closes #458 