### PR TITLE
Adds Phase III list items to repository

### DIFF
--- a/FMS.Domain/Repositories/IItemsListRepository.cs
+++ b/FMS.Domain/Repositories/IItemsListRepository.cs
@@ -9,17 +9,49 @@ namespace FMS.Domain.Repositories
     /// </summary>
     public interface IItemsListRepository : IDisposable
     {
+        #region "Get All List Items Lists"
+        /// <summary>
+        /// Get All List Items Lists
+        ///
         Task<IEnumerable<ListItem>> GetBudgetCodesItemListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetComplianceOfficersItemListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetFacilityStatusesItemListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetFacilityTypesItemListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetOrganizationalUnitsItemListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetCabinetsItemListAsync(bool includeInactive = false);
+
+        // Phase III updates
+        Task<IEnumerable<ListItem>> GetActionsTakenListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetContactTitlesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetContactTypesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetEventTypesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetFundingSourceListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetGroundwaterStatusesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetOverallStatusesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetParcelTypesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetSoilStatusesListAsync(bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetSourceStatusesListAsync(bool includeInactive = false);
+        #endregion
+
+        #region "Get Single List Item Names"
         Task<string> GetBudgetCodeNameAsync(Guid? id);
         Task<string> GetComplianceOfficerNameAsync(Guid? id);
         Task<string> GetFacilityStatusNameAsync(Guid? id);
         Task<string> GetFacilityTypeNameAsync(Guid? id);
         Task<string> GetOrganizationalUnitNameAsync(Guid? id);
+
+        //Phase III updates
+        Task<string> GetActionTakenNameAsync(Guid? id);
+        Task<string> GetContactTitleNameAsync(Guid? id);
+        Task<string> GetContactTypeNameAsync(Guid? id);
+        Task<string> GetEventTypeNameAsync(Guid? id);
+        Task<string> GetFundingSourceNameAsync(Guid? id);
+        Task<string> GetGroundwaterStatusNameAsync(Guid? id);
+        Task<string> GetOverallStatusNameAsync(Guid? id);
+        Task<string> GetParcelTypeNameAsync(Guid? id);
+        Task<string> GetSoilStatusNameAsync(Guid? id);
+        Task<string> GetSourceStatusNameAsync(Guid? id);
+        #endregion
     }
 
     public class ListItem

--- a/FMS.Infrastructure/Repositories/ItemsListRepository.cs
+++ b/FMS.Infrastructure/Repositories/ItemsListRepository.cs
@@ -14,11 +14,11 @@ namespace FMS.Infrastructure.Repositories
     /// Provides an class for retrieving lists of entities as key, value pairs
     /// </summary>
     public class ItemsListRepository : IItemsListRepository
-
     {
         private readonly FmsDbContext _context;
         public ItemsListRepository(FmsDbContext context) => _context = context;
 
+        #region "Get All List Items Lists"
         /// <summary>
         /// Generic method for retrieving a list of the given Entity as key/value pairs of the <see cref="ListItem"/> type.
         /// </summary>
@@ -66,6 +66,38 @@ namespace FMS.Infrastructure.Repositories
         public async Task<IEnumerable<ListItem>> GetCabinetsItemListAsync(bool includeInactive = false) =>
             await GetItemListAsync<Cabinet>(includeInactive);
 
+        // Phase III updates
+        public async Task<IEnumerable<ListItem>> GetActionsTakenListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<ActionTaken>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetContactTitlesListAsync(bool includeInactive = false) => 
+            await GetItemListAsync<ContactTitle>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetContactTypesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<ContactType>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetEventTypesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<EventType>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetFundingSourceListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<FundingSource>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetGroundwaterStatusesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<GroundwaterStatus>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetOverallStatusesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<OverallStatus>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetParcelTypesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<ParcelType>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetSoilStatusesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<SoilStatus>(includeInactive);
+
+        public async Task<IEnumerable<ListItem>> GetSourceStatusesListAsync(bool includeInactive = false) =>
+            await GetItemListAsync<SourceStatus>(includeInactive);
+
+        #endregion
 
         #region "Get single ListItem names"
 
@@ -136,6 +168,116 @@ namespace FMS.Infrastructure.Repositories
             return null;
         }
 
+        // Phase III updates
+        public async Task<string> GetActionTakenNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.ActionsTaken.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetContactTitleNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.ContactTitles.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetContactTypeNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.ContactTypes.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetEventTypeNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.EventTypes.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetFundingSourceNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.FundingSources.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetGroundwaterStatusNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.GroundwaterStatuses.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetOverallStatusNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.OverallStatuses.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetParcelTypeNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.ParcelTypes.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetSoilStatusNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.SoilStatuses.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
+
+        public async Task<string> GetSourceStatusNameAsync(Guid? id)
+        {
+            if (id.HasValue)
+            {
+                var item = await _context.SourceStatuses.AsNoTracking()
+                    .SingleOrDefaultAsync(e => e.Id == id);
+                return item?.Name;
+            }
+            return null;
+        }
         #endregion
 
         #region IDisposable Support

--- a/FMS.sln
+++ b/FMS.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30104.148
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36212.18 d17.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FMS", "FMS\FMS.csproj", "{67EEBCCE-ACDD-435B-926B-1A2620D248C5}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
Adds new methods to the IItemsListRepository interface and ItemsListRepository class to retrieve list items and names for Phase III entities. Includes methods for ActionsTaken, ContactTitles, ContactTypes, EventTypes, FundingSource, GroundwaterStatuses, OverallStatuses, ParcelTypes, SoilStatuses, and SourceStatuses.