### PR TITLE
Implement Event Repository

### DIFF
--- a/FMS.Domain/Repositories/IEventRepository.cs
+++ b/FMS.Domain/Repositories/IEventRepository.cs
@@ -10,7 +10,7 @@ namespace FMS.Domain.Repositories
     {
         Task<bool> EventExistsAsync(Guid id);
 
-        Task<Event> GetEventByIdAsync(Guid id);
+        Task<EventSummaryDto> GetEventByIdAsync(Guid id);
 
         Task<IEnumerable<Event>> GetEventsByFacilityIdAsync(Guid facilityId);
 

--- a/FMS.Domain/Repositories/IEventRepository.cs
+++ b/FMS.Domain/Repositories/IEventRepository.cs
@@ -12,13 +12,11 @@ namespace FMS.Domain.Repositories
 
         Task<EventEditDto> GetEventByIdAsync(Guid id);
 
-        Task<IEnumerable<Event>> GetEventsByFacilityIdAsync(Guid facilityId);
+        Task<IEnumerable<EventSummaryDto>> GetEventsByFacilityIdAsync(Guid facilityId);
 
-        Task<IEnumerable<Event>> GetEventsByFacilityIdAndStatusAsync(Guid facilityId, string status);
+        Task<IEnumerable<EventSummaryDto>> GetEventsByFacilityIdAndParentIdAsync(Guid facilityId, Guid parentId);
 
-        Task<IEnumerable<Event>> GetEventsByFacilityIdAndParentIdAsync(Guid facilityId, Guid parentId);
-
-        Task AddEventAsync(EventCreateDto eventDto);
+        Task<Guid> CreateEventAsync(EventCreateDto eventDto);
 
         Task UpdateEventAsync(EventEditDto eventDto);
 

--- a/FMS.Domain/Repositories/IEventRepository.cs
+++ b/FMS.Domain/Repositories/IEventRepository.cs
@@ -10,7 +10,7 @@ namespace FMS.Domain.Repositories
     {
         Task<bool> EventExistsAsync(Guid id);
 
-        Task<EventSummaryDto> GetEventByIdAsync(Guid id);
+        Task<EventEditDto> GetEventByIdAsync(Guid id);
 
         Task<IEnumerable<Event>> GetEventsByFacilityIdAsync(Guid facilityId);
 
@@ -22,6 +22,6 @@ namespace FMS.Domain.Repositories
 
         Task UpdateEventAsync(EventEditDto eventDto);
 
-        Task DeleteEventAsync(Guid id);
+        Task UpdateEventStatusAsync(Guid id, bool active);
     }
 }

--- a/FMS.Infrastructure/Repositories/EventRepository.cs
+++ b/FMS.Infrastructure/Repositories/EventRepository.cs
@@ -1,12 +1,96 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities;
+using FMS.Domain.Repositories;
+using FMS.Domain.Utils;
+using FMS.Infrastructure.Contexts;
+using Microsoft.EntityFrameworkCore;
 
 namespace FMS.Infrastructure.Repositories
 {
-    internal class EventRepository
+    public class EventRepository : IEventRepository
     {
+        private readonly FmsDbContext _context;
+        public EventRepository(FmsDbContext context) => _context = context;
+
+        public Task<bool> EventExistsAsync(Guid id) =>
+            _context.Events.AnyAsync(e => e.Id == id);
+
+        public async Task<EventEditDto> GetEventByIdAsync(Guid id)
+        {
+            var Event = await _context.Events.AsNoTracking()
+                .SingleOrDefaultAsync(e => e.Id == id);
+
+            return Event == null ? null : new EventEditDto(Event);
+        }
+
+        public Task<IEnumerable<Event>> GetEventsByFacilityIdAsync(Guid facilityId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<Event>> GetEventsByFacilityIdAndStatusAsync(Guid facilityId, string status)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IEnumerable<Event>> GetEventsByFacilityIdAndParentIdAsync(Guid facilityId, Guid parentId)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task AddEventAsync(EventCreateDto eventDto)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateEventAsync(EventEditDto eventDto)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdateEventStatusAsync(Guid id, bool active)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        #region IDisposable Support
+
+        private bool _disposedValue; // Corrected: 'private' modifier now precedes the member type
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposedValue) return;
+
+            if (disposing)
+            {
+                // dispose managed state (managed objects)
+                _context.Dispose();
+            }
+
+            // free unmanaged resources (unmanaged objects) and override finalizer
+            // set large fields to null
+            _disposedValue = true;
+        }
+
+        // override finalizer only if 'Dispose(bool disposing)' has code to free unmanaged resources
+        ~EventRepository()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: false);
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
     }
 }

--- a/FMS.Infrastructure/Repositories/EventRepository.cs
+++ b/FMS.Infrastructure/Repositories/EventRepository.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FMS.Infrastructure.Repositories
+{
+    internal class EventRepository
+    {
+    }
+}


### PR DESCRIPTION
Changes the return type of the GetEventByIdAsync method in the IEventRepository interface to EventSummaryDto.

This prepares for optimized data retrieval and avoids returning unnecessary data when only a summary is needed.