### PR TITLE
Adds Overall Status maintenance page

### DIFF
--- a/FMS.Domain/Dto/OverallStatus/OverallStatusCreateDto.cs
+++ b/FMS.Domain/Dto/OverallStatus/OverallStatusCreateDto.cs
@@ -11,5 +11,11 @@ namespace FMS.Domain.Dto
         [Display(Name = "Description")]
         [Required(ErrorMessage = "Description is required.")]
         public string Description { get; set; }
+
+        public void TrimAll()
+        {
+            Name = Name?.Trim();
+            Description = Description?.Trim();
+        }
     }
 }

--- a/FMS.Domain/Dto/OverallStatus/OverallStatusEditDto.cs
+++ b/FMS.Domain/Dto/OverallStatus/OverallStatusEditDto.cs
@@ -26,5 +26,11 @@ namespace FMS.Domain.Dto
         [Display(Name = "Description")]
         [Required(ErrorMessage = "Description is required.")]
         public string Description { get; set; }
+
+        public void TrimAll()
+        {
+            Name = Name?.Trim();
+            Description = Description?.Trim();
+        }
     }
 }

--- a/FMS/Pages/Maintenance/Index.cshtml
+++ b/FMS/Pages/Maintenance/Index.cshtml
@@ -42,4 +42,7 @@
     <li>
         <a class="nav-link" asp-page="GroundwaterStatus/Index">@MaintenanceOptions.GroundwaterStatus</a>
     </li>
+    <li>
+        <a class="nav-link" asp-page="OverallStatus/Index">@MaintenanceOptions.OverallStatus</a>
+    </li>
 </ul>

--- a/FMS/Pages/Maintenance/OverallStatus/Add.cshtml
+++ b/FMS/Pages/Maintenance/OverallStatus/Add.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model FMS.Pages.Maintenance.OverallStatus.AddModel
+@{
+}

--- a/FMS/Pages/Maintenance/OverallStatus/Add.cshtml
+++ b/FMS/Pages/Maintenance/OverallStatus/Add.cshtml
@@ -1,4 +1,36 @@
 ﻿@page
+@using FMS.Pages.Maintenance
 @model FMS.Pages.Maintenance.OverallStatus.AddModel
-@{
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
 }
+
+@{
+    ViewData["Title"] = $"Add {MaintenanceOptions.OverallStatus}";
+}
+<h1>@ViewData["Title"]</h1>
+<div class="container bg-light-subtle py-3 rounded-3">
+    <form method="post">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        <div class="row mb-3">
+            <div class="col-md-3">
+                <label asp-for="OverallStatus.Name">@MaintenanceOptions.OverallStatus Name <span class="text-danger">*</span></label>
+                <input asp-for="OverallStatus.Name" class="form-control" />
+                <span asp-validation-for="OverallStatus.Name" class="text-danger"></span>
+            </div>
+            <div class="col-md">
+                <label asp-for="OverallStatus.Description">@MaintenanceOptions.OverallStatus Description <span class="text-danger">*</span></label>
+                <input asp-for="OverallStatus.Description" class="form-control" />
+                <span asp-validation-for="OverallStatus.Description" class="text-danger"></span>
+            </div>
+        </div>
+        <hr />
+        <p class="text-danger">* denotes a required field</p>
+        <button id="SubmitButton" type="submit" class="btn btn-primary col-md-5 mb-3 mb-md-0">Add New @MaintenanceOptions.OverallStatus</button>
+        <a asp-page="Index" class="btn btn-outline-secondary col-md-2" asp-route-handler="select"
+           asp-route-MaintenanceSelection="@MaintenanceOptions.OverallStatus">
+            Cancel
+        </a>
+    </form>
+</div>

--- a/FMS/Pages/Maintenance/OverallStatus/Add.cshtml.cs
+++ b/FMS/Pages/Maintenance/OverallStatus/Add.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FMS.Pages.Maintenance.OverallStatus
+{
+    public class AddModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/FMS/Pages/Maintenance/OverallStatus/Add.cshtml.cs
+++ b/FMS/Pages/Maintenance/OverallStatus/Add.cshtml.cs
@@ -1,12 +1,54 @@
+using System.Threading.Tasks;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Repositories;
+using FMS.Platform.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace FMS.Pages.Maintenance.OverallStatus
 {
+    [Authorize(Roles = UserRoles.SiteMaintenance)]
     public class AddModel : PageModel
     {
+        private readonly IOverallStatusRepository _repository;
+        public AddModel(IOverallStatusRepository repository) => _repository = repository;
+
+        [BindProperty]
+        public OverallStatusCreateDto OverallStatus { get; set; }
+
         public void OnGet()
         {
+            // Method intentionally left empty.
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            OverallStatus.TrimAll();
+
+            if (await _repository.OverallStatusNameExistsAsync(OverallStatus.Name))
+            {
+                ModelState.AddModelError("OverallStatus.Name", "Name entered already exists.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            await _repository.CreateOverallStatusAsync(OverallStatus);
+
+            TempData?.SetDisplayMessage(Context.Success,
+                $"{MaintenanceOptions.OverallStatus} \"{OverallStatus.Name}\" successfully created.");
+
+            return RedirectToPage("./Index", "select",
+                new { MaintenanceSelection = MaintenanceOptions.OverallStatus });
         }
     }
 }

--- a/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml
+++ b/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml
@@ -1,4 +1,42 @@
-﻿@page
+﻿@page "{id:Guid?}"
+@using FMS.Pages.Maintenance
 @model FMS.Pages.Maintenance.OverallStatus.EditModel
-@{
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
 }
+
+@{
+    ViewData["Title"] = $"Edit {MaintenanceOptions.OverallStatus}: {Model.OverallStatus.Name}";
+}
+<h1>
+    @ViewData["Title"]
+    @if (!Model.OverallStatus.Active)
+    {
+        <span class="text-muted">(Removed)</span>
+    }
+</h1>
+
+<div class="container bg-light-subtle py-3 rounded-3">
+    <form method="post">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        <input type="hidden" asp-for="OverallStatus.Active" />
+        <input type="hidden" asp-for="Id" />
+        <div class="row mb-3">
+            <div class="col-md-3">
+                <label asp-for="OverallStatus.Name">@MaintenanceOptions.OverallStatus <span class="text-danger">*</span></label>
+                <input asp-for="OverallStatus.Name" class="form-control" aria-describedby="FileIdHelpBlock" />
+                <span asp-validation-for="OverallStatus.Name" class="text-danger"></span>
+            </div>
+            <div class="col-md">
+                <label asp-for="OverallStatus.Description">@MaintenanceOptions.OverallStatus Description <span class="text-danger">*</span></label>
+                <input asp-for="OverallStatus.Description" class="form-control" />
+                <span asp-validation-for="OverallStatus.Description" class="text-danger"></span>
+            </div>
+        </div>
+        <hr />
+        <p class="text-danger">* denotes a required field</p>
+        <button type="submit" class="btn btn-primary col-sm-3 mb-3 mb-sm-0">Save Changes</button>
+        <a asp-page="Index" class="btn btn-outline-secondary col-md-2">Cancel</a>
+    </form>
+</div>

--- a/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml
+++ b/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml
@@ -1,0 +1,4 @@
+﻿@page
+@model FMS.Pages.Maintenance.OverallStatus.EditModel
+@{
+}

--- a/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml.cs
+++ b/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace FMS.Pages.Maintenance.OverallStatus
+{
+    public class EditModel : PageModel
+    {
+        public void OnGet()
+        {
+        }
+    }
+}

--- a/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml.cs
+++ b/FMS/Pages/Maintenance/OverallStatus/Edit.cshtml.cs
@@ -1,12 +1,87 @@
+using System;
+using System.Threading.Tasks;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Repositories;
+using FMS.Platform.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 
 namespace FMS.Pages.Maintenance.OverallStatus
 {
+    [Authorize(Roles = UserRoles.SiteMaintenance)]
     public class EditModel : PageModel
     {
-        public void OnGet()
+        private readonly IOverallStatusRepository _repository;
+        public EditModel(IOverallStatusRepository repository) => _repository = repository;
+
+        [BindProperty]
+        public OverallStatusEditDto OverallStatus { get; set; }
+
+        [BindProperty]
+        public Guid Id { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(Guid? id)
         {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Id = id.Value;
+            OverallStatus = await _repository.GetOverallStatusAsync(id.Value);
+
+            if (OverallStatus == null)
+            {
+                return NotFound();
+            }
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            OverallStatus.TrimAll();
+
+            // If editing Code, make sure the new Code doesn't already exist before trying to save.
+            if (await _repository.OverallStatusNameExistsAsync(OverallStatus.Name, Id))
+            {
+                ModelState.AddModelError("OverallStatus.Name", "Name entered already exists.");
+            }
+
+            if (await _repository.OverallStatusNameExistsAsync(OverallStatus.Description, Id))
+            {
+                ModelState.AddModelError("OverallStatus.Description", "Description entered already exists.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            try
+            {
+                await _repository.UpdateOverallStatusAsync(Id, OverallStatus);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!await _repository.OverallStatusExistsAsync(Id))
+                {
+                    return NotFound();
+                }
+
+                throw;
+            }
+
+            TempData?.SetDisplayMessage(Context.Success, $"{MaintenanceOptions.OverallStatus} \"{OverallStatus.Name}\" successfully updated.");
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/FMS/Pages/Maintenance/OverallStatus/Index.cshtml
+++ b/FMS/Pages/Maintenance/OverallStatus/Index.cshtml
@@ -1,0 +1,54 @@
+﻿@page
+@using FMS.Pages.Maintenance
+@model FMS.Pages.Maintenance.OverallStatus.IndexModel
+
+@section Scripts {
+    <script src="~/js/formIndex.js"></script>
+}
+
+@{
+    ViewData["Title"] = $"Site Maintenance: {MaintenanceOptions.OverallStatus}";
+}
+
+<a asp-page="../Index">← Site Maintenance</a>
+<h1>
+    @MaintenanceOptions.OverallStatus <a asp-page="Add" class="btn btn-outline-primary btn-sm">Create New</a>
+</h1>
+<partial name="_AlertPartial" for="DisplayMessage" id="alert" />
+
+<form method="post">
+    <table class="table" aria-label="List of Overall Statuses">
+        <thead class="thead-light">
+            <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Description</th>
+                <th scope="col">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Model.OverallStatuses)
+            {
+                <tr class="@(!item.Active ? "table-warning" : "")">
+                    <td class="text-nowrap">
+                        @Html.DisplayFor(m => item.Name, "StringOrNone")
+                        @Html.DisplayFor(m => item.Active, "BoolRemoved")
+                    </td>
+                    <td class="text-nowrap">
+                        @Html.DisplayFor(m => item.Description, "StringOrNone")
+                    </td>
+                    <td class="text-nowrap">
+                        <a asp-page="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary btn-sm">Edit</a>
+                        @if (item.Active)
+                        {
+                            <button type="submit" name="itemId" value="@item.Id" class="btn btn-outline-warning btn-sm">Remove from list</button>
+                        }
+                        else
+                        {
+                            <button type="submit" name="itemId" value="@item.Id" class="btn btn-outline-warning btn-sm">Restore to list</button>
+                        }
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</form>

--- a/FMS/Pages/Maintenance/OverallStatus/Index.cshtml.cs
+++ b/FMS/Pages/Maintenance/OverallStatus/Index.cshtml.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Repositories;
+using FMS.Platform.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+
+namespace FMS.Pages.Maintenance.OverallStatus
+{
+    [Authorize(Roles = UserRoles.SiteMaintenance)]
+    public class IndexModel : PageModel
+    {
+        private readonly IOverallStatusRepository _repository;
+        public IndexModel(IOverallStatusRepository repository) => _repository = repository;
+
+        public IReadOnlyList<OverallStatusSummaryDto> OverallStatuses { get; private set; }
+        public DisplayMessage DisplayMessage { get; private set; }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            OverallStatuses = await _repository.GetOverallStatusListAsync();
+            DisplayMessage = TempData?.GetDisplayMessage();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync(Guid? itemId)
+        {
+            if (itemId == null)
+            {
+                return BadRequest();
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var overallStatus = await _repository.GetOverallStatusAsync(itemId.Value);
+
+            if (overallStatus == null)
+            {
+                return NotFound();
+            }
+
+            try
+            {
+                await _repository.UpdateOverallStatusStatusAsync(itemId.Value, !overallStatus.Active);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!await _repository.OverallStatusExistsAsync(itemId.Value))
+                {
+                    return NotFound();
+                }
+
+                throw;
+            }
+
+            TempData?.SetDisplayMessage(Context.Success,
+                overallStatus.Active
+                    ? $"{MaintenanceOptions.OverallStatus} \"{overallStatus.Name}\" successfully removed from list."
+                    : $"{MaintenanceOptions.OverallStatus} \"{overallStatus.Name}\" successfully restored.");
+
+            return RedirectToPage("./Index");
+        }
+    }
+}

--- a/FMS/Startup.cs
+++ b/FMS/Startup.cs
@@ -95,6 +95,7 @@ namespace FMS
             services.AddScoped<IEventTypeRepository, EventTypeRepository>();
             services.AddScoped<IFundingSourceRepository, FundingSourceRepository>();
             services.AddScoped<IGroundwaterStatusRepository, GroundwaterStatusRepository>();
+            services.AddScoped<IOverallStatusRepository, OverallStatusRepository>();
             services.AddScoped<IContactTypeRepository, ContactTypeRepository>();
             services.AddScoped<IContactTitleRepository, ContactTitleRepository>();
             services.AddScoped<IItemsListRepository, ItemsListRepository>();


### PR DESCRIPTION
Adds the Overall Status maintenance page and related functionality, allowing users with the appropriate roles to manage the list of overall statuses.

This includes adding the page to the maintenance index, creating the index, add, and edit pages, and implementing the logic to toggle the active status of an overall status item.