### PR TITLE
Adds Chemical edit functionality

### DIFF
--- a/FMS/Pages/Maintenance/Chemical/Edit.cshtml
+++ b/FMS/Pages/Maintenance/Chemical/Edit.cshtml
@@ -1,4 +1,59 @@
-﻿@page
-@model FMS.Pages.Maintenance.Chemicals.EditModel
-@{
+﻿@page "{id:Guid?}"
+@using FMS.Pages.Maintenance
+@model FMS.Pages.Maintenance.Chemical.EditModel
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
 }
+
+@{
+    ViewData["Title"] = $"Edit {MaintenanceOptions.Chemical}: {Model.Chemical.ChemicalName}";
+}
+<h1>
+    @ViewData["Title"]
+    @if (!Model.Chemical.Active)
+    {
+        <span class="text-muted">(Removed)</span>
+    }
+</h1>
+
+<div class="container bg-light-subtle py-3 rounded-3">
+    <form method="post">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        <input type="hidden" asp-for="Chemical.Active" />
+        <input type="hidden" asp-for="Id" />
+        <div class="row mb-3">
+            <div class="col-md-2">
+                <label asp-for="Chemical.CasNo">CasNo<span class="text-danger">*</span></label>
+                <input asp-for="Chemical.CasNo" class="form-control" aria-describedby="FileIdHelpBlock" />
+                <span asp-validation-for="Chemical.CasNo" class="text-danger"></span>
+            </div>
+            <div class="col-md-10">
+                <label asp-for="Chemical.ChemicalName">@($"{MaintenanceOptions.Chemical} Name")<span class="text-danger">*</span></label>
+                <input asp-for="Chemical.ChemicalName" class="form-control" />
+                <span asp-validation-for="Chemical.ChemicalName" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col-md-6">
+                <label asp-for="Chemical.CommonName">Common Name</label>
+                <input asp-for="Chemical.CommonName" class="form-control" />
+                <span asp-validation-for="Chemical.CommonName" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Chemical.ToxValue">Tox Value</label>
+                <input asp-for="Chemical.ToxValue" class="form-control" />
+                <span asp-validation-for="Chemical.ToxValue" class="text-danger"></span>
+            </div>
+            <div class="col-md-3">
+                <label asp-for="Chemical.MCLs">MCLs</label>
+                <input asp-for="Chemical.MCLs" class="form-control" />
+                <span asp-validation-for="Chemical.MCLs" class="text-danger"></span>
+            </div>
+        </div>
+        <hr />
+        <p class="text-danger">* denotes a required field</p>
+        <button type="submit" class="btn btn-primary col-sm-3 mb-3 mb-sm-0">Save Changes</button>
+        <a asp-page="Index" class="btn btn-outline-secondary col-md-2">Cancel</a>
+    </form>
+</div>

--- a/FMS/Pages/Maintenance/Chemical/Edit.cshtml.cs
+++ b/FMS/Pages/Maintenance/Chemical/Edit.cshtml.cs
@@ -1,12 +1,92 @@
+using System;
+using System.Threading.Tasks;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Repositories;
+using FMS.Platform.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 
-namespace FMS.Pages.Maintenance.Chemicals
+namespace FMS.Pages.Maintenance.Chemical
 {
+    [Authorize(Roles = UserRoles.SiteMaintenance)]
     public class EditModel : PageModel
     {
-        public void OnGet()
+        private readonly IChemicalRepository _repository;
+        public EditModel(IChemicalRepository repository) => _repository = repository;
+
+        [BindProperty]
+        public ChemicalEditDto Chemical { get; set; }
+
+        [BindProperty]
+        public Guid Id { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(Guid? id)
         {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Id = id.Value;
+            Chemical = await _repository.GetChemicalByIdAsync(id.Value);
+
+            if (Chemical == null)
+            {
+                return NotFound();
+            }
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            Chemical.TrimAll();
+
+            // If editing Chemical, make sure the new Chemical doesn't already exist before trying to save.
+            if (await _repository.ChemicalCasNoExistsAsync(Chemical.CasNo, Id))
+            {
+                ModelState.AddModelError("Chemical.CasNo", "CasNo entered already exists.");
+            }
+
+            if (await _repository.ChemicalChemicalNameExistsAsync(Chemical.ChemicalName, Id))
+            {
+                ModelState.AddModelError("Chemical.ChemicalName", "Chemical Name entered already exists.");
+            }
+
+            if (await _repository.ChemicalCommonNameExistsAsync(Chemical.CommonName, Id))
+            {
+                ModelState.AddModelError("Chemical.CommonName", "Common Name entered already exists.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            try
+            {
+                await _repository.UpdateChemicalAsync(Id, Chemical);
+            }
+            catch (DbUpdateConcurrencyException)
+            {
+                if (!await _repository.ChemicalExistsAsync(Id))
+                {
+                    return NotFound();
+                }
+
+                throw;
+            }
+
+            TempData?.SetDisplayMessage(Context.Success, $"{MaintenanceOptions.Chemical} \"{Chemical.ChemicalName}\" successfully updated.");
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/FMS/wwwroot/js/formIndex.js
+++ b/FMS/wwwroot/js/formIndex.js
@@ -1,3 +1,3 @@
 ﻿$(document).ready(function formIndex() {
-    setTimeout(function () { $('.alert').alert('close') }, 10000)
+    setTimeout(function () { $('.alert').alert('close') }, 6000)
 });


### PR DESCRIPTION
Implements the edit page for the Chemical entity in the maintenance section.

This includes:
- Creating the Razor Page and corresponding PageModel.
- Implementing validation to prevent duplicate records (CasNo, ChemicalName, CommonName).
- Using EditDto object for data transfer.
- Displaying success message upon updating the Chemical.

Also adjusts the alert timeout.