### PR TITLE
Adds Parcel edit functionality

### DIFF
--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -460,8 +460,8 @@
                                             @if (Model.FacilityDetail.Active && User.IsInRole(UserRoles.FileEditor))
                                             {
                                                 <td>
-                                                    <a asp-page="./Location/Edit" asp-route-id="@p.Id" class="btn btn-sm btn-outline-primary">Edit</a>
-                                                    <a asp-page="./Location/Delete" asp-route-id="@p.Id" class="btn btn-sm btn-outline-danger">Delete</a>
+                                                    <a asp-page="/Parcel/Edit" asp-route-id="@p.Id" class="btn btn-sm btn-outline-primary">Edit</a>
+                                                    <a asp-page="/Parcel/Delete" asp-route-id="@p.Id" class="btn btn-sm btn-outline-danger">Delete</a>
                                                 </td>
                                             }
                                         </tr>

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -461,7 +461,7 @@
                                             {
                                                 <td>
                                                     <a asp-page="/Parcel/Edit" asp-route-id="@p.Id" class="btn btn-sm btn-outline-primary">Edit</a>
-                                                    <a asp-page="/Parcel/Delete" asp-route-id="@p.Id" class="btn btn-sm btn-outline-danger">Delete</a>
+                                                    <a asp-page="/Parcel/Delete" asp-route-id="@p.Id" class="btn btn-sm btn-outline-danger">Remove</a>
                                                 </td>
                                             }
                                         </tr>

--- a/FMS/Pages/Parcel/Edit.cshtml
+++ b/FMS/Pages/Parcel/Edit.cshtml
@@ -1,0 +1,62 @@
+﻿@page "{id:Guid?}"
+@using FMS.Pages.Parcel
+@using FMS.Domain.Entities.Users
+@model FMS.Pages.Parcel.EditModel
+@section Scripts
+{
+    <partial name="_ValidationScriptsPartial" />
+}
+
+@{
+    ViewData["Title"] = "Edit Parcel";
+}
+<h1>@ViewData["Title"]</h1>
+<hr />
+<div class="p-3 rounded-3 bg-light-subtle">
+    <form method="post">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        <input type="hidden" asp-for="EditParcel.FacilityId" />
+        <input type="hidden" asp-for="EditParcel.Id" />
+        <input type="hidden" asp-for="EditParcel.Active" />
+        <div class="row">
+            <div class="col">
+                <label asp-for="EditParcel.ParcelNumber"></label>
+                <input asp-for="EditParcel.ParcelNumber" class="form-control" />
+                <span asp-validation-for="EditParcel.ParcelNumber" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="EditParcel.Acres"></label>
+                <input asp-for="EditParcel.Acres" class="form-control" />
+                <span asp-validation-for="EditParcel.Acres" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="EditParcel.ParcelTypeId"></label>
+                <select asp-for="EditParcel.ParcelTypeId" asp-items="Model.ParcelTypes" class="form-select">
+                    <option value="">-- Select Parcel Type --</option>
+                </select>
+                <span asp-validation-for="EditParcel.ParcelTypeId" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col">
+                <label asp-for="EditParcel.ListDate" class="form-label"></label>
+                <input asp-for="EditParcel.ListDate" class="form-control datepicker" type="date" placeholder="" />
+                <span asp-validation-for="EditParcel.ListDate" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="EditParcel.DeListDate" class="form-label"></label>
+                <input asp-for="EditParcel.DeListDate" class="form-control datepicker" type="date" placeholder="" />
+                <span asp-validation-for="EditParcel.DeListDate" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="EditParcel.SubListParcelName" class="form-label
+    text-center"></label>
+                <input asp-for="EditParcel.SubListParcelName" class="form-control text-center" />
+                <span asp-validation-for="EditParcel.SubListParcelName" class="text-danger"></span>
+            </div>
+        </div>
+        <hr />
+        <button type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Save Changes</button>
+        <a asp-page="../Facilities/Details" asp-route-Id="@Model.EditParcel.FacilityId" class="btn btn-outline-secondary col-md-2">Cancel</a>
+    </form>
+</div>

--- a/FMS/Pages/Parcel/Edit.cshtml
+++ b/FMS/Pages/Parcel/Edit.cshtml
@@ -51,7 +51,7 @@
             <div class="col">
                 <label asp-for="EditParcel.SubListParcelName" class="form-label
     text-center"></label>
-                <input asp-for="EditParcel.SubListParcelName" class="form-control text-center" />
+                <input asp-for="EditParcel.SubListParcelName" class="form-control" />
                 <span asp-validation-for="EditParcel.SubListParcelName" class="text-danger"></span>
             </div>
         </div>

--- a/FMS/Pages/Parcel/Edit.cshtml.cs
+++ b/FMS/Pages/Parcel/Edit.cshtml.cs
@@ -1,0 +1,73 @@
+using FMS.Domain.Dto;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Entities;
+using FMS.Domain.Repositories;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System;
+using System.Threading.Tasks;
+
+namespace FMS.Pages.Parcel
+{
+    [Authorize(Policy = UserPolicies.FileCreatorOrEditor)]
+    public class EditModel : PageModel
+    {
+        private readonly IParcelRepository _repository;
+        private readonly ISelectListHelper _listHelper;
+
+        public EditModel(
+            IParcelRepository repository,
+            ISelectListHelper listHelper)
+        {
+            _repository = repository;
+            _listHelper = listHelper;
+        }
+
+        [BindProperty]
+        public ParcelEditDto EditParcel { get; set; }
+
+        public SelectList ParcelTypes { get; private set; }
+
+        [BindProperty]
+        public Guid Id { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(Guid id)
+        {
+            Id = id;
+            EditParcel = await _repository.GetParcelByIdAsync(id);
+            if (EditParcel == null)
+            {
+                return NotFound();
+            }
+            await PopulateSelectsAsync();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                await PopulateSelectsAsync();
+                return Page();
+            }
+            try
+            {
+                await _repository.UpdateParcelAsync(EditParcel.Id, EditParcel);
+                return RedirectToPage("../Facilities/Details", new { id = EditParcel.FacilityId });
+            }
+            catch (Exception ex)
+            {
+                ModelState.AddModelError(string.Empty, $"An error occurred while updating the parcel. Please try again. Error Detail: \"{ex}\"");
+                await PopulateSelectsAsync();
+                return Page();
+            }
+        }
+
+        private async Task PopulateSelectsAsync()
+        {
+            ParcelTypes = await _listHelper.ParcelTypesSelectListAsync();
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to edit Parcel information.

This change introduces a new page for editing parcel details, allowing users with appropriate permissions to modify parcel attributes such as Parcel Number, Acres, Parcel Type, and Dates.

The edit page includes validation to ensure data integrity and provides a cancel button to return to the facility details page.