### PR TITLE
Adds active status to parcel edit page

### DIFF
--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -461,7 +461,6 @@
                                             {
                                                 <td>
                                                     <a asp-page="/Parcel/Edit" asp-route-id="@p.Id" class="btn btn-sm btn-outline-primary">Edit</a>
-                                                    <a asp-page="/Parcel/Delete" asp-route-id="@p.Id" class="btn btn-sm btn-outline-danger">Remove</a>
                                                 </td>
                                             }
                                         </tr>

--- a/FMS/Pages/Parcel/Edit.cshtml
+++ b/FMS/Pages/Parcel/Edit.cshtml
@@ -17,7 +17,6 @@
         <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
         <input type="hidden" asp-for="EditParcel.FacilityId" />
         <input type="hidden" asp-for="EditParcel.Id" />
-        <input type="hidden" asp-for="EditParcel.Active" />
         <div class="row">
             <div class="col">
                 <label asp-for="EditParcel.ParcelNumber"></label>
@@ -53,6 +52,12 @@
     text-center"></label>
                 <input asp-for="EditParcel.SubListParcelName" class="form-control" />
                 <span asp-validation-for="EditParcel.SubListParcelName" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="row mt-3">
+            <div class="col">
+                <input asp-for="EditParcel.Active" class="form-check-input" type="checkbox" />
+                <label asp-for="EditParcel.Active" class="form-check-label"></label>
             </div>
         </div>
         <hr />


### PR DESCRIPTION
Updates the parcel edit page to include a checkbox for the active status of the parcel.

Removes the delete link from the facility details page for parcels and hides the active property. This change allows users to easily enable or disable a parcel without permanently deleting it.