### PR TITLE
Adds functionality to create Substances

### DIFF
--- a/FMS.Domain/Dto/Substance/SubstanceCreateDto.cs
+++ b/FMS.Domain/Dto/Substance/SubstanceCreateDto.cs
@@ -6,6 +6,12 @@ namespace FMS.Domain.Dto
 {
     public class SubstanceCreateDto
     {
+        public SubstanceCreateDto() { }
+
+        public Guid Id { get; set; }
+
+        public bool Active { get; set; }
+
         [Required]
         public Guid FacilityId { get; set; }
 

--- a/FMS.Domain/Repositories/ISubstanceRepository.cs
+++ b/FMS.Domain/Repositories/ISubstanceRepository.cs
@@ -21,7 +21,7 @@ namespace FMS.Domain.Repositories
 
         Task<Guid> CreateSubstanceAsync(SubstanceCreateDto substance);
 
-        Task UpdateSubstanceAsync(Guid Id, SubstanceEditDto substanceUpdates);
+        Task UpdateSubstanceAsync(Guid id, SubstanceEditDto substanceUpdates);
 
         Task UpdateSubstanceStatusAsync(Guid id, bool active);
     }

--- a/FMS/FMS.csproj
+++ b/FMS/FMS.csproj
@@ -64,7 +64,6 @@
 <ItemGroup>
   <Folder Include="Pages\Event\" />
   <Folder Include="Pages\SoilScore\" />
-  <Folder Include="Pages\Substance\" />
 </ItemGroup>
 
 </Project>

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -785,7 +785,7 @@
                     <div class="tab-pane" id="Substances" role="tabpanel" aria-labelledby="Substances-tab">
                         <h3>
                             Substances
-                            <a asp-page="/Substance/Add" class="btn btn-sm btn-primary">Add Substance</a>
+                            <a asp-page="/Substance/Add" asp-route-id="@Model.FacilityDetail.Id" class="btn btn-sm btn-primary">Add Substance</a>
                         </h3>
                         <hr />
                         <div class="row justify-content-evenly">
@@ -819,8 +819,7 @@
                                             @if (Model.FacilityDetail.Active && User.IsInRole(UserRoles.FileEditor))
                                             {
                                                 <td>
-                                                    <a asp-page="./Substance/Edit" asp-route-id="@s.Id" class="btn btn-sm btn-outline-primary">Edit</a>
-                                                    <a asp-page="./Substance/Delete" asp-route-id="@s.Id" class="btn btn-sm btn-outline-danger">Remove</a>
+                                                    <a asp-page="/Substance/Edit" asp-route-id="@s.Id" class="btn btn-sm btn-outline-primary">Edit</a>
                                                 </td>
                                             }
                                         </tr>

--- a/FMS/Pages/Substance/Add.cshtml
+++ b/FMS/Pages/Substance/Add.cshtml
@@ -1,0 +1,66 @@
+﻿@page "{id:Guid?}"
+@using FMS.Pages.Substance
+@using FMS.Domain.Entities.Users
+@model FMS.Pages.Substance.AddModel
+
+@section Scripts
+{
+    <partial name="_ValidationScriptsPartial" />
+}
+
+@{
+    ViewData["Title"] = "Add Substance";
+}
+<h1>@ViewData["Title"]</h1>
+<div class="container bg-light-subtle py-3 rounded-3">
+    <form method="post">
+        <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
+        <input type="hidden" asp-for="NewSubstance.Id" />
+        <input type="hidden" asp-for="NewSubstance.FacilityId" />
+        <div class="row">
+            <div class="col">
+                <label asp-for="NewSubstance.ChemicalId"></label>
+                <select asp-for="NewSubstance.ChemicalId" asp-items="Model.Chemicals" class="form-select">
+                    <option value=""></option>
+                </select>
+                <span asp-validation-for="NewSubstance.ChemicalId" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="NewSubstance.Chemical.CasNo"></label>
+                <input asp-for="NewSubstance.Chemical.CasNo" class="form-control" />
+                <span asp-validation-for="NewSubstance.Chemical.CasNo" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="NewSubstance.Chemical.ChemicalName"></label>
+                <input asp-for="NewSubstance.Chemical.ChemicalName" class="form-control" />
+                <span asp-validation-for="NewSubstance.Chemical.ChemicalName" class="text-danger"></span>
+            </div>
+            <div class="col">
+                <label asp-for="NewSubstance.Chemical.CommonName"></label>
+                <input asp-for="NewSubstance.Chemical.CommonName" class="form-control" />
+                <span asp-validation-for="NewSubstance.Chemical.CommonName" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="row mt-3">
+            <div class="col">
+                <input asp-for="NewSubstance.Groundwater" class="form-check-input" type="checkbox" />
+                <label asp-for="NewSubstance.Groundwater" class="form-check-label"></label>
+            </div>
+            <div class="col">
+                <input asp-for="NewSubstance.Soil" class="form-check-input" type="checkbox" />
+                <label asp-for="NewSubstance.Soil" class="form-check-label"></label>
+            </div>
+            <div class="col">
+                <input asp-for="NewSubstance.UseForScoring" class="form-check-input" type="checkbox" />
+                <label asp-for="NewSubstance.UseForScoring" class="form-check-label"></label>
+            </div>
+            <div class="col">
+                <input asp-for="NewSubstance.Active" class="form-check-input" type="checkbox" />
+                <label asp-for="NewSubstance.Active" class="form-check-label"></label>
+            </div>
+        </div>
+        <hr />
+        <button type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Create New Substance</button>
+        <a asp-page="../Facilities/Details" asp-route-Id="@Model.NewSubstance.FacilityId" class="btn btn-outline-secondary col-md-2">Cancel</a>
+    </form>
+</div>

--- a/FMS/Pages/Substance/Add.cshtml.cs
+++ b/FMS/Pages/Substance/Add.cshtml.cs
@@ -1,0 +1,84 @@
+using FMS.Domain.Data;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Repositories;
+using FMS.Helpers;
+using FMS.Pages.Maintenance;
+using FMS.Platform.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FMS.Pages.Substance
+{
+    [Authorize(Policy = UserPolicies.FileCreatorOrEditor)]
+    public class AddModel : PageModel
+    {
+        private readonly ISubstanceRepository _repository;
+        private readonly ISelectListHelper _listHelper;
+
+        public AddModel(
+            ISubstanceRepository repository,
+            ISelectListHelper listHelper)
+        {
+            _repository = repository;
+            _listHelper = listHelper;
+        }
+        [BindProperty]
+        public SubstanceCreateDto NewSubstance { get; set; }
+
+        public SelectList Chemicals { get; private set; }
+
+        public async Task<IActionResult> OnGetAsync(Guid? id)
+        {
+            if (id == null || id == Guid.Empty)
+            {
+                return NotFound();
+            }
+
+            NewSubstance = new SubstanceCreateDto
+            {
+                FacilityId = id.Value,
+                Active = true
+            };
+
+            await PopulateSelectsAsync();
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                await PopulateSelectsAsync();
+                return Page();
+            }
+            try
+            {
+                var newId = await _repository.CreateSubstanceAsync(NewSubstance);
+
+                TempData?.SetDisplayMessage(Context.Success, "The substance was created successfully.");
+
+                return RedirectToPage("../Facilities/Details", new { id = NewSubstance.FacilityId, tab = "substances" });
+            }
+            catch (Exception ex)
+            {
+                ModelState.AddModelError(string.Empty, ex.Message);
+                await PopulateSelectsAsync();
+                return Page();
+            }
+        }
+
+        private async Task PopulateSelectsAsync()
+        {
+            Chemicals = await _listHelper.ChemicalsSelectListAsync();
+        }
+    }
+}

--- a/FMS/Startup.cs
+++ b/FMS/Startup.cs
@@ -113,7 +113,7 @@ namespace FMS
             services.AddScoped<IScoreRepository, ScoreRepository>();
             services.AddScoped<IGroundwaterScoreRepository, GroundwaterScoreRepository>();
             services.AddScoped<IOnsiteScoreRepository, OnsiteScoreRepository>();
-
+            services.AddScoped<ISubstanceRepository, SubstanceRepository>();
 
             // Set up database
             services.AddHostedService<MigratorHostedService>();


### PR DESCRIPTION
Introduces the ability to create new substance records via a dedicated "Add Substance" page. This includes UI elements for inputting substance details and integrating with the backend to persist these records. It also adds a link from the facility details page to create a new substance for the given facility.