### PR TITLE
Update and pin GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/raygun-deployment.yml
+++ b/.github/workflows/raygun-deployment.yml
@@ -19,8 +19,8 @@ jobs:
         run: echo ::set-output name=VERSION::${GITHUB_REF##*/}
 
       - name: Send to the Raygun Deployments API
-        id: send_deployment
-        uses: fjogeleit/http-request-action@v1.16.4
+        id: raygun_deployment
+        uses: fjogeleit/http-request-action@1297c6fc63a79b147d1676540a3fd9d2e37817c5
         with:
           url: https://app.raygun.com/deployments?authToken=${{ secrets.RAYGUN_AUTHTOKEN }}
           method: POST

--- a/.github/workflows/sonarcloud-scan.yml
+++ b/.github/workflows/sonarcloud-scan.yml
@@ -18,22 +18,23 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Set up Java JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165
         with:
           java-version: 17
           distribution: "zulu" # Alternative distribution options are available.
 
-      - uses: actions/checkout@v4
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
         with:
           global-json-file: global.json
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: ~\sonar\cache
           key: ${{ runner.os }}-sonar
@@ -41,7 +42,7 @@ jobs:
 
       - name: Cache SonarCloud scanner
         id: cache-sonar-scanner
-        uses: actions/cache@v4
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809
         with:
           path: .\.sonar\scanner
           key: ${{ runner.os }}-sonar-scanner
@@ -65,9 +66,9 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         shell: powershell
         run: |
-          .\.sonar\scanner\dotnet-sonarscanner begin /k:"gaepdit_FMS" /o:"gaepdit" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=coverage.xml /d:sonar.exclusions=FMS.Infrastructure/Migrations/**,FMS/Platform/DevHelpers/SeedData/**
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"gaepdit_FMS" /o:"gaepdit" /d:sonar.token="$env:SONAR_TOKEN" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.cs.opencover.reportsPaths=coverage.xml /d:sonar.exclusions=FMS.Infrastructure/Migrations/**,FMS/Platform/DevHelpers/SeedData/**
           dotnet build
           coverlet .\artifacts\FMS.Domain.Tests\bin\Debug\net9.0\FMS.Domain.Tests.dll --target "dotnet" --targetargs "test tests/FMS.Domain.Tests --no-build"
           coverlet .\artifacts\FMS.App.Tests\bin\Debug\net9.0\FMS.App.Tests.dll --target "dotnet" --targetargs "test tests/FMS.App.Tests --no-build" --exclude "[TestHelpers]*" --exclude "[FMS.Infrastructure]FMS.Infrastructure.Migrations.*" --merge-with "coverage.json"
           coverlet .\artifacts\FMS.Infrastructure.Tests\bin\Debug\net9.0\FMS.Infrastructure.Tests.dll --target "dotnet" --targetargs "test tests/FMS.Infrastructure.Tests --no-build" --exclude "[TestHelpers]*" --exclude "[FMS.Infrastructure]FMS.Infrastructure.Migrations.*" --merge-with "coverage.json" -f=opencover -o="coverage.xml"
-          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.token="$env:SONAR_TOKEN"


### PR DESCRIPTION
This PR updates the GitHub actions and pins any referenced third-party actions to a specific commit SHA for improved security. This PR also enables Dependabot updates for GitHub actions.

See https://github.com/gaepdit/EPD-IT/issues/166 and [Secure use reference - GitHub Docs](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions) for background.

Since only GH actions are modified, this shouldn't affect build or deploy in any way.