### PR TITLE
Handles null reference exceptions in score entities

### DIFF
--- a/FMS.Domain/Dto/GroundwaterScore/GroundwaterScoreEditDto.cs
+++ b/FMS.Domain/Dto/GroundwaterScore/GroundwaterScoreEditDto.cs
@@ -19,13 +19,13 @@ namespace FMS.Domain.Dto
             B2 = groundwaterScore.B2;
             C = groundwaterScore.C;
             Description = groundwaterScore.Description;
-            ChemName = groundwaterScore.Chemical.ChemicalName;
-            Other = groundwaterScore.Chemical.CommonName;
+            ChemName = groundwaterScore.Chemical?.ChemicalName;
+            Other = groundwaterScore.Chemical?.CommonName;
             D2 = groundwaterScore.D2;
             D3 = groundwaterScore.D3;
-            ChemicalId = groundwaterScore.ChemicalId;
-            Chemical = groundwaterScore.Chemical;
-            CASNO = groundwaterScore.Chemical.CasNo;
+            ChemicalId = groundwaterScore?.ChemicalId;
+            Chemical = groundwaterScore?.Chemical;
+            CASNO = groundwaterScore.Chemical?.CasNo;
             E1 = groundwaterScore.E1;
             E2 = groundwaterScore.E2;
         }

--- a/FMS.Domain/Dto/OnSiteScore/OnsiteScoreEditDto.cs
+++ b/FMS.Domain/Dto/OnSiteScore/OnsiteScoreEditDto.cs
@@ -18,13 +18,13 @@ namespace FMS.Domain.Dto
             B = onsiteScore.B;
             C = onsiteScore.C;
             Description = onsiteScore.Description;
-            ChemName1D = onsiteScore.Chemical.ChemicalName;
+            ChemName1D = onsiteScore.Chemical?.ChemicalName;
             ChemicalId = onsiteScore.ChemicalId;
             Chemical = onsiteScore.Chemical;
             Other1D = onsiteScore.Other1D;
             D2 = onsiteScore.D2;
             D3 = onsiteScore.D3;
-            CASNO = onsiteScore.Chemical.CasNo;
+            CASNO = onsiteScore.Chemical?.CasNo;
             E1 = onsiteScore.E1;
             E2 = onsiteScore.E2;
         }

--- a/FMS.Infrastructure/Repositories/GroundwaterScoreRepository.cs
+++ b/FMS.Infrastructure/Repositories/GroundwaterScoreRepository.cs
@@ -52,7 +52,7 @@ namespace FMS.Infrastructure.Repositories
                 Other = groundwaterScore.Other,
                 D2 = groundwaterScore.D2,
                 D3 = groundwaterScore.D3,
-                ChemicalId = groundwaterScore.ChemicalId,
+                ChemicalId = null,
                 CASNO = groundwaterScore.CASNO,
                 E1 = groundwaterScore.E1,
                 E2 = groundwaterScore.E2

--- a/FMS.Infrastructure/Repositories/OnsiteScoreRepository.cs
+++ b/FMS.Infrastructure/Repositories/OnsiteScoreRepository.cs
@@ -51,6 +51,7 @@ namespace FMS.Infrastructure.Repositories
                 D2 = onsiteScore.D2,
                 D3 = onsiteScore.D3,
                 CASNO = onsiteScore.CASNO,
+                ChemicalId = null,
                 E1 = onsiteScore.E1,
                 E2 = onsiteScore.E2
             };

--- a/FMS.Infrastructure/Repositories/StatusRepository.cs
+++ b/FMS.Infrastructure/Repositories/StatusRepository.cs
@@ -45,6 +45,14 @@ namespace FMS.Infrastructure.Repositories
         {
             var newStatus = new Status(status);
 
+            newStatus.AbandonSitesId = null;
+            newStatus.FundingSourceId = null;
+            newStatus.GAPSAssessmentId = null;
+            newStatus.GroundwaterStatusId = null;
+            newStatus.OverallStatusId = null;
+            newStatus.SoilStatusId = null;
+            newStatus.SourceStatusId = null;
+
             if (status.FacilityId == Guid.Empty)
             {
                 throw new ArgumentException("FacilityId cannot be empty.", nameof(status));

--- a/FMS/Pages/HsrpFacilityProperties/Edit.cshtml
+++ b/FMS/Pages/HsrpFacilityProperties/Edit.cshtml
@@ -24,6 +24,7 @@
             <div class="col mb-3">
                 <label asp-for="HsrpFacilityProperties.ComplianceOfficerId" class="form-label">Geologist</label>
                 <select asp-for="HsrpFacilityProperties.ComplianceOfficerId" asp-items="Model.ComplianceOfficers" class="form-select">
+                    <option value=""></option>
                 </select>
                 <span asp-validation-for="HsrpFacilityProperties.ComplianceOfficerId" class="text-danger"></span>
             </div>
@@ -35,6 +36,7 @@
             <div class="col mb-3">
                 <label asp-for="HsrpFacilityProperties.OrganizationalUnitId" class="form-label">Additional Org. Unit</label>
                 <select asp-for="HsrpFacilityProperties.OrganizationalUnitId" asp-items="Model.OrganizationalUnit" class="form-select">
+                    <option value=""></option>
                 </select>
                 <span asp-validation-for="HsrpFacilityProperties.OrganizationalUnitId" class="text-danger"></span>
             </div>

--- a/FMS/Pages/Score/Edit.cshtml
+++ b/FMS/Pages/Score/Edit.cshtml
@@ -25,6 +25,7 @@
             <div class="col mb-3">
                 <label asp-for="Score.ScoredById" class="form-label">Scored By</label>
                 <select asp-for="Score.ScoredById" asp-items="Model.ComplianceOfficers" class="form-select">
+                    <option value=""></option>
                 </select>
                 <span asp-validation-for="Score.ScoredById" class="text-danger"></span>
             </div>


### PR DESCRIPTION
Addresses potential null reference exceptions when accessing related entities in GroundwaterScoreEditDto and OnsiteScoreEditDto.

Sets ChemicalId to null in GroundwaterScoreRepository and OnsiteScoreRepository to avoid unexpected behavior with missing chemical associations.

Also, sets default null values for dropdownlist on edit pages.

Updates StatusRepository to ensure any associations are cleared when creating a new status to prevent errors with old Facility data.