### PR TITLE
Update and pin GH action for unit tests

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -15,11 +15,11 @@ jobs:
     name: Run unit tests
     runs-on: windows-latest
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
+      - name: Check out repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d
         with:
           global-json-file: global.json
 


### PR DESCRIPTION
Updates the GitHub action I missed in #752. This should fix the issue with unit tests not running in other PRs.