### PR TITLE
Adds endpoint to retrieve allowed event types

### DIFF
--- a/FMS.Domain/Repositories/IItemsListRepository.cs
+++ b/FMS.Domain/Repositories/IItemsListRepository.cs
@@ -23,6 +23,7 @@ namespace FMS.Domain.Repositories
         // Phase III updates
         Task<IEnumerable<ListItem>> GetActionsTakenListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetAllowedActionsTakenListAsync(Guid? id, bool includeInactive = false);
+        Task<IEnumerable<ListItem>> GetAllowedEventsListAsync(Guid? id, bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetChemicalListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetContactTitlesListAsync(bool includeInactive = false);
         Task<IEnumerable<ListItem>> GetContactTypesListAsync(bool includeInactive = false);

--- a/FMS.Infrastructure/Repositories/ItemsListRepository.cs
+++ b/FMS.Infrastructure/Repositories/ItemsListRepository.cs
@@ -77,6 +77,13 @@ namespace FMS.Infrastructure.Repositories
             .Select(e => new ListItem() { Id = e.ActionTaken.Id, Name = e.ActionTaken.Name })
             .ToListAsync();
 
+        public async Task<IEnumerable<ListItem>> GetAllowedEventsListAsync(Guid? id, bool includeInactive = false) => await _context.AllowedActionsTaken.AsNoTracking()
+            .Where(e => (e.ActionTakenId == id) && (e.Active || includeInactive))
+            .Include(e => e.EventType)
+            .OrderBy(e => e.EventType.Name)
+            .Select(e => new ListItem() { Id = e.EventType.Id, Name = e.EventType.Name })
+            .ToListAsync();
+
         public async Task<IEnumerable<ListItem>> GetChemicalListAsync(bool includeInactive = false) => 
             await _context.Chemicals.AsNoTracking()
             .Where(e => e.Active || includeInactive)

--- a/FMS/Api/ActionEventController.cs
+++ b/FMS/Api/ActionEventController.cs
@@ -25,7 +25,7 @@ namespace FMS.Api
     {
         [HttpGet("{id:guid}")]
         public async Task<IActionResult> GetAllowedEventsAsync([FromRoute] Guid id) =>
-            new JsonResult(await _listHelper.AllowedActionTakenSelectListAsync(id));
+            new JsonResult(await _listHelper.AllowedEventsSelectListAsync(id));
     }
 }
 

--- a/FMS/Api/ActionEventController.cs
+++ b/FMS/Api/ActionEventController.cs
@@ -1,0 +1,31 @@
+﻿using DocumentFormat.OpenXml.Office2010.Excel;
+using FMS.Domain.Dto;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Repositories;
+using FMS.Domain.Services;
+using FMS.Platform.Extensions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using TestSupport.SeedDatabase;
+
+namespace FMS.Api
+{
+    [Authorize]
+    [ApiController]
+    [Route("api")]
+    [Produces("application/json")]
+    public class ActionEventController(
+        ISelectListHelper _listHelper) : ControllerBase
+    {
+        [HttpGet("{id:guid}")]
+        public async Task<IActionResult> GetAllowedEventsAsync([FromRoute] Guid id) =>
+            new JsonResult(await _listHelper.AllowedActionTakenSelectListAsync(id));
+    }
+}
+

--- a/FMS/Helpers/SelectListHelper.cs
+++ b/FMS/Helpers/SelectListHelper.cs
@@ -18,6 +18,7 @@ namespace FMS
         // Phase III updates
         Task<SelectList> ActionTakenSelectListAsync(bool includeInactive = false);
         Task<SelectList> AllowedActionTakenSelectListAsync(Guid? id, bool includeInactive = false);
+        Task<SelectList> AllowedEventsSelectListAsync(Guid? id, bool includeInactive = false);
         Task<SelectList> ChemicalsSelectListAsync(bool includeInactive = false);
         Task<SelectList> ContactTitlesSelectListAsync(bool includeInactive = false);
         Task<SelectList> ContactTypesSelectListAsync(bool includeInactive = false);
@@ -54,6 +55,7 @@ namespace FMS
         public async Task<SelectList> ActionTakenSelectListAsync(bool includeInactive = false) =>
             (await _listRepository.GetActionsTakenListAsync(includeInactive)).ToSelectList();
         public async Task<SelectList> AllowedActionTakenSelectListAsync(Guid? id, bool includeInactive = false) => (await _listRepository.GetAllowedActionsTakenListAsync(id, includeInactive)).ToSelectList();
+        public async Task<SelectList> AllowedEventsSelectListAsync(Guid? id, bool includeInactive = false) => (await _listRepository.GetAllowedEventsListAsync(id, includeInactive)).ToSelectList();
         public async Task<SelectList> ChemicalsSelectListAsync(bool includeInactive = false) =>
             (await _listRepository.GetChemicalListAsync(includeInactive)).ToSelectList();
         public async Task<SelectList> ContactTitlesSelectListAsync(bool includeInactive = false) =>

--- a/FMS/Pages/Event/Add.cshtml
+++ b/FMS/Pages/Event/Add.cshtml
@@ -13,6 +13,13 @@
             "NewEvent_ActionTakenId",
             "None Selected");
     </script>
+    <partial name="_EventSelectPartial" />
+    <script>
+        setUpEventTypeDropdown(
+            "NewEvent_ActionTakenId",
+            "NewEvent_EventTypeId",
+            "None Selected");
+    </script>
 }
 
 @{

--- a/FMS/Pages/Event/Edit.cshtml
+++ b/FMS/Pages/Event/Edit.cshtml
@@ -13,6 +13,13 @@
             "EditEvent_ActionTakenId",
             "None Selected");
     </script>
+    <partial name="_EventSelectPartial" />
+    <script>
+        setUpEventTypeDropdown(
+            "EditEvent_ActionTakenId",
+            "EditEvent_EventTypeId",
+            "None Selected");
+    </script>
 }
 
 @{

--- a/FMS/Pages/Event/Edit.cshtml.cs
+++ b/FMS/Pages/Event/Edit.cshtml.cs
@@ -90,7 +90,7 @@ namespace FMS.Pages.Event
 
         private async Task PopulateSelectsAsync()
         {
-            EventTypes = await _listHelper.EventTypesSelectListAsync();
+            EventTypes = await _listHelper.AllowedEventsSelectListAsync(EditEvent.ActionTakenId);
             AllowedActionsTaken = await _listHelper.AllowedActionTakenSelectListAsync(EditEvent.EventTypeId);
             ComplianceOfficers = await _listHelper.ComplianceOfficersSelectListAsync();
         }

--- a/FMS/Pages/Shared/_EventSelectPartial.cshtml
+++ b/FMS/Pages/Shared/_EventSelectPartial.cshtml
@@ -1,0 +1,2 @@
+﻿<script src="~/lib/axios/axios.min.js" integrity="sha512-6VJrgykcg/InSIutW2biLwA1Wyq+7bZmMivHw19fI+ycW0jIjsadm8wKQQLlfv3YUS4owfMDlZU38NtaAK6fSg=="></script>
+<script src="~/js/eventSelect.js"></script>

--- a/FMS/wwwroot/js/actionSelect.js
+++ b/FMS/wwwroot/js/actionSelect.js
@@ -5,7 +5,11 @@ function setUpActionTypeDropdown(eventElementId, actionElementId, placeholder) {
 
     eventSelect.addEventListener("change", () => {
         const actionSelect = document.getElementById(actionElementId);
-        actionSelect.innerHTML = `<option value="">${placeholder}</option>`;
+        if (actionSelect.innerHTML === '') {
+            actionSelect.innerHTML = `<option value="">${placeholder}</option>`
+        } else {
+            return;
+        };
         actionSelect.disabled = false;
         if (eventSelect.value === '') return;
 

--- a/FMS/wwwroot/js/eventSelect.js
+++ b/FMS/wwwroot/js/eventSelect.js
@@ -1,0 +1,36 @@
+﻿// Populate the EventType dropdown when an EventType selection is made.
+function setUpEventTypeDropdown(actionElementId, eventElementId, placeholder) {
+
+    const actionSelect = document.getElementById(actionElementId);
+
+    actionSelect.addEventListener("change", () => {
+        const eventSelect = document.getElementById(eventElementId);
+        if (eventSelect.innerHTML === '') {
+            eventSelect.innerHTML = `<option value="">${placeholder}</option>`
+        } else{
+            return;
+        };
+        eventSelect.disabled = false;
+        if (actionSelect.value === '') return;
+
+        axios.get(`/api/${actionSelect.value}`)
+            .then(function (response) {
+                const data = response.data;
+                if (data == null || data.length === 0) return;
+
+                let opt;
+                for (const item of data) {
+                    opt = document.createElement('option');
+                    opt.text = item.text;
+                    opt.value = item.value;
+                    eventSelect.add(opt);
+                }
+            })
+            .catch(function errorHandler(error) {
+                eventSelect.innerHTML = '<option value="">Error</option>';
+                if (error instanceof Error && typeof rg4js === "function") {
+                    rg4js('send', { error: error, tags: ['handled_promise_rejection'] });
+                }
+            });
+    });
+}


### PR DESCRIPTION
This commit introduces a new API endpoint that allows retrieval of allowed event types based on a given action type ID.

It also adds the necessary repository methods and helper functions to fetch and format the data for the endpoint.

This change enables filtering of event types based on the selected action type, improving user experience and data integrity.