### PR TITLE
Displays Funding Source Description

### DIFF
--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -907,7 +907,7 @@
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.FundingSource)
                             </dt>
                             <dd class="col-sm-3 pt-3">
-                                @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.FundingSource.Name, "StringOrNone")
+                                @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.FundingSource.DisplayName, "StringOrNone")
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.LandFill)
@@ -960,7 +960,7 @@
                             <dt class="col-sm-2 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.Comments)
                             </dt>
-                            <dd class="col-sm-8 pt-3">
+                            <dd class="col-sm-4 pt-3">
                                 <textarea readonly enabled="false" class="form-control" rows="3" id="GAPSComments">@Html.DisplayFor(model => model.FacilityDetail.StatusDetails.Comments)</textarea>
                             </dd>
                         </dl>

--- a/tests/TestHelpers/SeedData/FundingSourceSeedData.cs
+++ b/tests/TestHelpers/SeedData/FundingSourceSeedData.cs
@@ -17,36 +17,42 @@ namespace FMS.TestData.SeedData
                     Id = new Guid("97E9B7AF-5A60-4426-812A-8F6B5B2CB635"),
                     Active = true,
                     Name = "A",
+                    Description = "Abandoned",
                 },
                 new()
                 {
                     Id = new Guid("DEACC0E4-AB9F-4A16-8B66-FB7512731AB5"),
                     Active = true,
                     Name = "LE",
+                    Description = "Local Government Eligible",
                 },
                 new()
                 {
                     Id = new Guid("65A97123-4BCA-478C-B110-E0F149DFCCD1"),
                     Active = true,
                     Name = "LI",
+                    Description = "Local Government Ineligible",
                 },
                 new()
                 {
                     Id = new Guid("5DD80C99-665C-475C-8799-203915D6E668"),
                     Active = true,
                     Name = "P",
+                    Description = "Private",
                 },
                 new()
                 {
                     Id = new Guid("5F857A62-65B0-475D-B31C-A1F685C5C002"),
                     Active = true,
                     Name = "SE",
+                    Description = "State Government Eligible",
                 },
                 new()
                 {
                     Id = new Guid("CEDC5C85-E355-4458-A283-323D8F7D075A"),
                     Active = true,
                     Name = "SI",
+                    Description = "State Government Ineligible",
                 }
             };
         }


### PR DESCRIPTION
Updates the facility details page to display the funding source description instead of the name.

Adds descriptions to the FundingSource seed data for clarity in tests.

Improves user experience by providing more context for funding sources.

Related to #827