### PR TITLE
Fixes event parent selection on add page

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilityDetailDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityDetailDto.cs
@@ -198,6 +198,6 @@ namespace FMS.Domain.Dto
 
         public Status StatusDetails { get; set; }
 
-        public List<EventSummaryDto> Events { get; }
+        public IList<EventSummaryDto> Events { get; set; }
     }
 }

--- a/FMS.Domain/Repositories/IEventRepository.cs
+++ b/FMS.Domain/Repositories/IEventRepository.cs
@@ -14,9 +14,9 @@ namespace FMS.Domain.Repositories
 
         Task<EventSummaryDto> GetEventSummaryByIdAsync(Guid id);
 
-        Task<IEnumerable<EventSummaryDto>> GetEventsByFacilityIdAsync(Guid facilityId);
+        Task<IList<EventSummaryDto>> GetEventsByFacilityIdAsync(Guid facilityId);
 
-        Task<IEnumerable<EventSummaryDto>> GetEventsByFacilityIdAndParentIdAsync(Guid facilityId, Guid parentId);
+        Task<IList<EventSummaryDto>> GetEventsByFacilityIdAndParentIdAsync(Guid facilityId, Guid parentId);
 
         Task<Guid> CreateEventAsync(EventCreateDto eventDto);
 

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -138,8 +138,7 @@ namespace FMS.Infrastructure.Repositories
                     .ToListAsync();
 
                 facility.Events = facility.Events
-                    .OrderByDescending(e => e.Active)
-                    .ThenBy(e => e.StartDate)
+                    .OrderBy(e => e.StartDate)
                     .GroupBy(e => e.ParentId?.ToString() ?? string.Empty)
                     .SelectMany(g => g)
                     .ToList();

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -139,6 +139,7 @@ namespace FMS.Infrastructure.Repositories
 
                 facility.Events = facility.Events
                     .OrderBy(e => e.StartDate)
+                    .ThenBy(e => e.CompletionDate)
                     .GroupBy(e => e.ParentId?.ToString() ?? string.Empty)
                     .SelectMany(g => g)
                     .ToList();

--- a/FMS/Helpers/EventSortHelper.cs
+++ b/FMS/Helpers/EventSortHelper.cs
@@ -1,0 +1,36 @@
+﻿using FMS.Domain.Dto;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace FMS.Helpers
+{
+    public static class EventSortHelper
+    {
+        public static IList<EventSummaryDto> SortEvents(IList<EventSummaryDto> events)
+        {
+            var sortedList = new List<EventSummaryDto>();
+
+            // Get top-level parents
+            var topLevelParents = events.Where(e => e.ParentId == Guid.Empty).OrderBy(e => e.StartDate).ThenBy(e => e.CompletionDate);
+
+            foreach (var parent in topLevelParents)
+            {
+                sortedList.Add(parent);
+                AddChildrenRecursively(parent, events, sortedList);
+            }
+
+            return sortedList;
+        }
+
+        private static void AddChildrenRecursively(EventSummaryDto parent, IList<EventSummaryDto> allEvents, List<EventSummaryDto> sortedList)
+        {
+            var children = allEvents.Where(c => c.ParentId == parent.Id).OrderBy(c => c.StartDate).ThenBy(e => e.CompletionDate);
+            foreach (var child in children)
+            {
+                sortedList.Add(child);
+                AddChildrenRecursively(child, allEvents, sortedList);
+            }
+        }
+    }
+}

--- a/FMS/Pages/Event/Add.cshtml
+++ b/FMS/Pages/Event/Add.cshtml
@@ -20,61 +20,66 @@
 }
 <h1>@ViewData["Title"]</h1>
 <form method="post">
-    @if (Model.Facility.FacilityStatus.Name == "COMPLAINT" || Model.Facility.FacilityStatus.Name == "Event Tracking On")
-    {
-        <div class="container bg-light-subtle py-3 rounded-3">
-            <p>Select a Master Project as the Parent for this new Event, if applicable.</p>
-            <div class="row justify-content-evenly">
-                <table class="table table-sm" aria-label="Events">
-                    <thead class="thead-light">
-                        <tr>
-                            <th scope="col"><em class="">Select Parent</em>  Event Type</th>
-                            <th scope="col">Action Taken</th>
-                            <th scope="col">Start Date</th>
-                            <th scope="col">Due Date</th>
-                            <th scope="col">Completion Date</th>
-                            <th scope="col">Done By</th>
-                            <th scope="col">Event Amount</th>
-                            <th scope="col">Contractor</th>
-                            <th scope="col">Comment</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var e in Model.Facility.Events)
+    @*  @if (Model.Facility.FacilityStatus.Name == "COMPLAINT" || Model.Facility.FacilityStatus.Name == "Event Tracking On")
+    { *@
+    <div class="container bg-light-subtle py-3 rounded-3">
+        <p>Select a Master Project as the Parent for this new Event, if applicable.</p>
+        <div class="row justify-content-evenly">
+            <table class="table table-sm" aria-label="Events">
+                <thead class="thead-light">
+                    <tr>
+                        <th scope="col"><em class="">Select Parent</em>  Event Type</th>
+                        <th scope="col">Action Taken</th>
+                        <th scope="col">Start Date</th>
+                        <th scope="col">Due Date</th>
+                        <th scope="col">Completion Date</th>
+                        <th scope="col">Done By</th>
+                        <th scope="col">Event Amount</th>
+                        <th scope="col">Contractor</th>
+                        <th scope="col">Comment</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in Model.Facility.Events)
+                    {
+                        if (item.EventType.Name == "HWTF Master Project")
                         {
-                            if (e.EventType.Name == "HWTF Master Project")
-                            {
-                                <tr class="@(!e.Active ? "text-muted table-warning" : "")">
-                                    <td class="text-nowrap">
-                                        <label>
-                                            @Html.RadioButtonFor(m => m.ParentEventId, e.Id)
-                                            @Html.DisplayFor(m => e.EventType.Name)
-                                        </label>
-                                    </td>
-                                    <td>@e.ActionTaken.Name</td>
-                                    <td>@e.StartDate</td>
-                                    <td>@e.DueDate</td>
-                                    <td>@e.CompletionDate</td>
-                                    <td>@e.ComplianceOfficer.Name</td>
-                                    <td>@e.EventAmount</td>
-                                    <td>@e.EventContractor?.Name</td>
-                                    <td>@e.Comment</td>
-                                </tr>
-                            }
+                            <tr class="@(!item.Active ? "text-muted table-warning" : "")">
+                                <td class="text-nowrap">
+                                    <label>
+                                        @Html.RadioButtonFor(m => m.ParentEventId, item.Id)
+                                        @Html.DisplayFor(m => item.EventType.Name)
+                                    </label>
+                                </td>
+                                <td>@Html.DisplayFor(m => item.ActionTaken.Name)</td>
+                                <td>@Html.DisplayFor(m => item.StartDate)</td>
+                                <td>@Html.DisplayFor(m => item.DueDate)</td>
+                                <td>@Html.DisplayFor(m => item.CompletionDate)</td>
+                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
+                                <td>@Html.DisplayFor(m => item.EventAmount)</td>
+                                <td>
+                                    @if (item.EventContractor != null)
+                                    {
+                                        @Html.DisplayFor(m => item.EventContractor.Name)
+                                    }
+                                </td>
+                                <td>@Html.DisplayFor(m => item.Comment)</td>
+                            </tr>
                         }
-                        <tr>
-                            <td colspan="12">
-                                <label class="active">
-                                    @Html.RadioButtonFor(m => m.ParentEventId, string.Empty)
-                                    None
-                                </label>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                    }
+                    <tr>
+                        <td colspan="12">
+                            <label class="active">
+                                @Html.RadioButtonFor(m => m.ParentEventId, Guid.Empty)
+                                None
+                            </label>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
-    }
+    </div>
+    @*   } *@
     <div class="container bg-light-subtle py-3 my-3 rounded-3">
         <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
         <input type="hidden" asp-for="NewEvent.FacilityId" />
@@ -162,19 +167,22 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var e in Model.Facility.Events)
+                        @foreach (var item in Model.Facility.Events)
                         {
-                            <tr class="@(!e.Active ? "text-muted table-warning" : "")">
-                                <td>@e.EventType.Name</td>
-                                <td>@e.ActionTaken.Name</td>
-                                <td>@e.StartDate</td>
-                                <td>@e.DueDate</td>
-                                <td>@e.CompletionDate</td>
-                                <td>@e.ComplianceOfficer.Name</td>
-                                <td>@e.EventAmount</td>
-                                <td>@e.EventContractor?.Name</td>
-                                <td>@e.Comment</td>
-                            </tr>
+                            @* @if (item.EventType.Name != "HWTF Master Project")
+                            { *@
+                                <tr class="@(item.ParentId != Guid.Empty ? "text-muted table-warning" : "")">
+                                    <td>@item.EventType.Name</td>
+                                    <td>@item.ActionTaken.Name</td>
+                                    <td>@item.StartDate</td>
+                                    <td>@item.DueDate</td>
+                                    <td>@item.CompletionDate</td>
+                                    <td>@item.ComplianceOfficer.Name</td>
+                                    <td>@item.EventAmount</td>
+                                    <td>@item.EventContractor?.Name</td>
+                                    <td>@item.Comment</td>
+                                </tr>
+                            @* } *@
                         }
                     </tbody>
                 </table>

--- a/FMS/Pages/Event/Add.cshtml
+++ b/FMS/Pages/Event/Add.cshtml
@@ -28,7 +28,7 @@
             <table class="table table-sm" aria-label="Events">
                 <thead class="thead-light">
                     <tr>
-                        <th scope="col"><em class="">Select Parent</em>  Event Type</th>
+                        <th scope="col"><em class="">Select Parent Master Project</em></th>
                         <th scope="col">Action Taken</th>
                         <th scope="col">Start Date</th>
                         <th scope="col">Due Date</th>
@@ -167,22 +167,26 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var item in Model.Facility.Events)
+                        @for (var i = 0; i < Model.Events.Count; i++)
                         {
-                            @* @if (item.EventType.Name != "HWTF Master Project")
-                            { *@
-                                <tr class="@(item.ParentId != Guid.Empty ? "text-muted table-warning" : "")">
-                                    <td>@item.EventType.Name</td>
-                                    <td>@item.ActionTaken.Name</td>
-                                    <td>@item.StartDate</td>
-                                    <td>@item.DueDate</td>
-                                    <td>@item.CompletionDate</td>
-                                    <td>@item.ComplianceOfficer.Name</td>
-                                    <td>@item.EventAmount</td>
-                                    <td>@item.EventContractor?.Name</td>
-                                    <td>@item.Comment</td>
-                                </tr>
-                            @* } *@
+                            var item = Model.Events[i];
+                            <tr class="@((item.ParentId != Guid.Empty ? "text-muted table-warning" : "") + (item.EventType.Name == "HWTF Master Project" ? " table-info" : ""))">
+                                <td>
+                                    @if (item.ParentId != Guid.Empty)
+                                    {
+                                        <span class="badge text-bg-info"> ^ </span>
+                                    }
+                                    @item.EventType.Name
+                                </td>
+                                <td>@item.ActionTaken.Name</td>
+                                <td>@item.StartDate</td>
+                                <td>@item.DueDate</td>
+                                <td>@item.CompletionDate</td>
+                                <td>@item.ComplianceOfficer.Name</td>
+                                <td>@item.EventAmount</td>
+                                <td>@item.EventContractor?.Name</td>
+                                <td>@item.Comment</td>
+                            </tr>
                         }
                     </tbody>
                 </table>

--- a/FMS/Pages/Event/Add.cshtml.cs
+++ b/FMS/Pages/Event/Add.cshtml.cs
@@ -46,7 +46,7 @@ namespace FMS.Pages.Event
         [BindProperty]
         public Guid? ParentEventId { get; set; } = Guid.Empty;
 
-        public IEnumerable<EventSummaryDto> Events { get; set; }
+        public IList<EventSummaryDto> Events { get; set; }
 
         public SelectList EventTypes { get; private set; }
         public SelectList AllowedActionsTaken { get; private set; }
@@ -56,7 +56,7 @@ namespace FMS.Pages.Event
         [TempData]
         public string ActiveTab { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(Guid? id, Guid? parentId)
+        public async Task<IActionResult> OnGetAsync(Guid? id)
         {
             if (id == null || id == Guid.Empty)
             {
@@ -66,16 +66,16 @@ namespace FMS.Pages.Event
 
             Facility = await _facilityRepository.GetFacilityAsync(Id);
 
-            Events = parentId.HasValue
-                ? await _repository.GetEventsByFacilityIdAndParentIdAsync(Id, parentId.Value)
-                : await _repository.GetEventsByFacilityIdAsync(Id);
+            Events = await _repository.GetEventsByFacilityIdAsync(Id);
 
-            parentId ??= Guid.Empty;
+            ParentEventId ??= Guid.Empty;
+
+            Events = EventSortHelper.SortEvents(Events);
 
             NewEvent = new EventCreateDto
             {
                 FacilityId = Id,
-                ParentId = parentId
+                ParentId = ParentEventId
             };
 
             ActiveTab = "Events";

--- a/FMS/Pages/Event/Edit.cshtml
+++ b/FMS/Pages/Event/Edit.cshtml
@@ -20,61 +20,63 @@
 }
 <h1>@ViewData["Title"]</h1>
 <form method="post">
-    @if (Model.Facility.FacilityStatus.Name == "COMPLAINT" || Model.Facility.FacilityStatus.Name == "Event Tracking On")
-    {
-        <div class="container bg-light-subtle py-3 rounded-3">
-            <p>Select a Master Project as the Parent for this new Event, if applicable.</p>
-            <div class="row justify-content-evenly">
-                <table class="table table-sm" aria-label="Events">
-                    <thead class="thead-light">
-                        <tr>
-                            <th scope="col"><em class="">Select Parent</em>  Event Type</th>
-                            <th scope="col">Action Taken</th>
-                            <th scope="col">Start Date</th>
-                            <th scope="col">Due Date</th>
-                            <th scope="col">Completion Date</th>
-                            <th scope="col">Done By</th>
-                            <th scope="col">Event Amount</th>
-                            <th scope="col">Entity Name or No.</th>
-                            <th scope="col">Comment</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var e in Model.Facility.Events)
+    <div class="container bg-light-subtle py-3 rounded-3">
+        <p>Select a Master Project as the Parent for this new Event, if applicable.</p>
+        <div class="row justify-content-evenly">
+            <table class="table table-sm" aria-label="Events">
+                <thead class="thead-light">
+                    <tr>
+                        <th scope="col"><em class="">Select Parent Master Project</em></th>
+                        <th scope="col">Action Taken</th>
+                        <th scope="col">Start Date</th>
+                        <th scope="col">Due Date</th>
+                        <th scope="col">Completion Date</th>
+                        <th scope="col">Done By</th>
+                        <th scope="col">Event Amount</th>
+                        <th scope="col">Entity Name or No.</th>
+                        <th scope="col">Comment</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in Model.Facility.Events)
+                    {
+                        if (item.EventType.Name == "HWTF Master Project")
                         {
-                            if (e.EventType.Name == "HWTF Master Project")
-                            {
-                                <tr class="@(!e.Active ? "text-muted table-warning" : "")">
-                                    <td class="text-nowrap">
-                                        <label>
-                                            @Html.RadioButtonFor(m => m.ParentEventId, e.Id)
-                                            @Html.DisplayFor(m => e.EventType.Name)
-                                        </label>
-                                    </td>
-                                    <td>@e.ActionTaken.Name</td>
-                                    <td>@e.StartDate</td>
-                                    <td>@e.DueDate</td>
-                                    <td>@e.CompletionDate</td>
-                                    <td>@e.ComplianceOfficer.Name</td>
-                                    <td>@e.EventAmount</td>
-                                    <td>@e.EventContractor.Name</td>
-                                    <td>@e.Comment</td>
-                                </tr>
-                            }
+                            <tr class="@(item.Id == Model.Id ? " table-danger" : "")">
+                                <td class="text-nowrap">
+                                    <label>
+                                        @Html.RadioButtonFor(m => m.ParentEventId, item.Id)
+                                        @Html.DisplayFor(m => item.EventType.Name)
+                                    </label>
+                                </td>
+                                <td>@Html.DisplayFor(m => item.ActionTaken.Name)</td>
+                                <td>@Html.DisplayFor(m => item.StartDate)</td>
+                                <td>@Html.DisplayFor(m => item.DueDate)</td>
+                                <td>@Html.DisplayFor(m => item.CompletionDate)</td>
+                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
+                                <td>@Html.DisplayFor(m => item.EventAmount)</td>
+                                <td>
+                                    @if (item.EventContractor != null)
+                                    {
+                                        @Html.DisplayFor(m => item.EventContractor.Name)
+                                    }
+                                </td>
+                                <td>@Html.DisplayFor(m => item.Comment)</td>
+                            </tr>
                         }
-                        <tr>
-                            <td colspan="12">
-                                <label class="active">
-                                    @Html.RadioButtonFor(m => m.ParentEventId, string.Empty)
-                                    None
-                                </label>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                    }
+                    <tr>
+                        <td colspan="12">
+                            <label class="active">
+                                @Html.RadioButtonFor(m => m.ParentEventId, Guid.Empty)
+                                None
+                            </label>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
         </div>
-    }
+    </div>
     <div class="container bg-light-subtle py-3 my-3 rounded-3">
         <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
         <input type="hidden" asp-for="EditEvent.FacilityId" />
@@ -164,18 +166,30 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var e in Model.Facility.Events)
+                        @for (var i = 0; i < Model.Events.Count; i++)
                         {
-                            <tr class="@(!e.Active ? "text-muted table-warning" : "")">
-                                <td>@e.EventType.Name</td>
-                                <td>@e.ActionTaken.Name</td>
-                                <td>@e.StartDate</td>
-                                <td>@e.DueDate</td>
-                                <td>@e.CompletionDate</td>
-                                <td>@e.ComplianceOfficer.Name</td>
-                                <td>@e.EventAmount</td>
-                                <td>@e.EventContractor?.Name</td>
-                                <td>@e.Comment</td>
+                            var item = Model.Events[i];
+                            <tr class="@((item.ParentId != Guid.Empty ? "text-muted table-warning" : "") + (item.EventType.Name == "HWTF Master Project" ? " table-info" : "") + (item.Id == Model.Id ? " table-danger" : ""))">
+                                <td>
+                                    @if (item.ParentId != Guid.Empty)
+                                    {
+                                        <span class="badge text-bg-info"> ^ </span>
+                                    }
+                                    @item.EventType.Name
+                                </td>
+                                <td>@Html.DisplayFor(m => item.ActionTaken.Name)</td>
+                                <td>@Html.DisplayFor(m => item.StartDate)</td>
+                                <td>@Html.DisplayFor(m => item.DueDate)</td>
+                                <td>@Html.DisplayFor(m => item.CompletionDate)</td>
+                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
+                                <td>@Html.DisplayFor(m => item.EventAmount)</td>
+                                <td>
+                                    @if (item.EventContractor != null)
+                                    {
+                                        @Html.DisplayFor(m => item.EventContractor.Name)
+                                    }
+                                </td>
+                                <td>@Html.DisplayFor(m => item.Comment)</td>
                             </tr>
                         }
                     </tbody>

--- a/FMS/Pages/Event/Edit.cshtml.cs
+++ b/FMS/Pages/Event/Edit.cshtml.cs
@@ -3,12 +3,14 @@ using FMS.Domain.Dto;
 using FMS.Domain.Entities;
 using FMS.Domain.Entities.Users;
 using FMS.Domain.Repositories;
+using FMS.Helpers;
 using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace FMS.Pages.Event
@@ -38,6 +40,8 @@ namespace FMS.Pages.Event
         [BindProperty]
         public Guid? ParentEventId { get; set; } = Guid.Empty;
 
+        public IList<EventSummaryDto> Events { get; set; }
+
         public SelectList EventTypes { get; private set; }
         public SelectList AllowedActionsTaken { get; private set; }
         public SelectList ComplianceOfficers { get; private set; }
@@ -58,6 +62,8 @@ namespace FMS.Pages.Event
                 return NotFound();
             }
             Facility = await _facilityRepository.GetFacilityAsync(EditEvent.FacilityId);
+            ParentEventId = EditEvent.ParentId == Guid.Empty ? null : EditEvent.ParentId;
+            Events = EventSortHelper.SortEvents(Facility.Events);
 
             await PopulateSelectsAsync();
             ActiveTab = "Events";
@@ -73,6 +79,7 @@ namespace FMS.Pages.Event
             }
             try
             {
+                EditEvent.ParentId = ParentEventId ?? Guid.Empty;
                 await _repository.UpdateEventAsync(EditEvent);
             }
             catch (Exception ex)

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -1042,23 +1042,30 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                @foreach (var e in Model.FacilityDetail.Events)
+                                @for (var i = 0; i < Model.FacilityDetail.Events.Count; i++)
                                 {
-                                    <tr class="@(!e.Active ? "text-muted table-warning" : "")">
-                                        <td>@e.EventType.Name</td>
-                                        <td>@e.ActionTaken.Name</td>
-                                        <td>@e.StartDate</td>
-                                        <td>@e.DueDate</td>
-                                        <td>@e.CompletionDate</td>
-                                        <td>@e.ComplianceOfficer?.Name</td>
-                                        <td>@e.EventAmount</td>
-                                        <td>@e.EventContractor?.Name</td>
-                                        <td>@e.Comment</td>
+                                    var item = Model.FacilityDetail.Events[i];
+                                    <tr class="@((item.ParentId != Guid.Empty ? "text-muted table-warning" : "") + (item.EventType.Name == "HWTF Master Project" ? " table-info" : ""))">
+                                        <td>
+                                            @if (item.ParentId != Guid.Empty)
+                                            {
+                                                <span class="badge text-bg-info"> ^ </span>
+                                            }
+                                            @item.EventType.Name
+                                        </td>
+                                        <td>@item.ActionTaken.Name</td>
+                                        <td>@item.StartDate</td>
+                                        <td>@item.DueDate</td>
+                                        <td>@item.CompletionDate</td>
+                                        <td>@item.ComplianceOfficer.Name</td>
+                                        <td>@item.EventAmount</td>
+                                        <td>@item.EventContractor?.Name</td>
+                                        <td>@item.Comment</td>
                                         @if (Model.FacilityDetail.Active && User.IsInRole(UserRoles.FileEditor))
                                         {
                                             <td>
-                                                <a asp-page="/Event/Edit" asp-route-id="@e.Id" class="btn btn-sm btn-outline-primary">Edit</a>
-                                                <a asp-page="/Event/Delete" asp-route-id="@e.Id" class="btn btn-sm btn-outline-danger">Delete</a>
+                                                <a asp-page="/Event/Edit" asp-route-id="@item.Id" class="btn btn-sm btn-outline-primary">Edit</a>
+                                                <a asp-page="/Event/Delete" asp-route-id="@item.Id" class="btn btn-sm btn-outline-danger">Delete</a>
                                             </td>
                                         }
                                     </tr>

--- a/FMS/Pages/Facilities/Details.cshtml.cs
+++ b/FMS/Pages/Facilities/Details.cshtml.cs
@@ -93,10 +93,8 @@ namespace FMS.Pages.Facilities
                 ActiveTab = "HSIProperties";
             }
 
-            Lat = FacilityDetail.Latitude != 0 ? FacilityDetail.Latitude.ToString() : null;
-            Lon = FacilityDetail.Longitude != 0 ? FacilityDetail.Longitude.ToString() : null;
             MapLink = GetMapLink();
-
+            FacilityDetail.Events = EventSortHelper.SortEvents(FacilityDetail.Events);
             FacilityId = FacilityDetail.Id;
             Message = TempData?.GetDisplayMessage();
             return Page();
@@ -133,7 +131,7 @@ namespace FMS.Pages.Facilities
             }
 
             RecordCreate.TrimAll();
-
+            GetMapLink();
             HighlightRecord = await _repository.CreateRetentionRecordAsync(FacilityId, RecordCreate);
 
             return RedirectToPage();
@@ -143,6 +141,8 @@ namespace FMS.Pages.Facilities
         {
             if (FacilityDetail != null && FacilityDetail.Latitude != 0 && FacilityDetail.Longitude != 0)
             {
+                Lat = FacilityDetail.Latitude.ToString();
+                Lon = FacilityDetail.Longitude.ToString();
                 return UrlHelper.GetMapLink(FacilityDetail.Latitude, FacilityDetail.Longitude);
             }
             return string.Empty;

--- a/tests/TestHelpers/SeedData/AllowedActionTakenSeedData.cs
+++ b/tests/TestHelpers/SeedData/AllowedActionTakenSeedData.cs
@@ -95,6 +95,27 @@ namespace FMS.TestData.SeedData
                     Active = true,
                     ActionTakenId = new Guid("51e5d358-f991-4574-a21b-79ccfa31ac9d"),   //Issued
                     EventTypeId = new Guid("F1A8BCAD-B09E-42BB-ABFD-74E230567A65"),   //HWTF Master Project
+                },
+                new()
+                {
+                    Id = new Guid("86ED497B-7DA7-4961-B0A4-FEE0A066A1CB"),
+                    Active = true,
+                    ActionTakenId = new Guid("6aae6fa2-17ca-4edd-9c59-87c6af3885c3"),   //Draft Received
+                    EventTypeId = new Guid("4CF16FE7-B240-49DE-AB17-0595DDD45F4E"),   //HWTF Request for Advance
+                },
+                new()
+                {
+                    Id = new Guid("24A52FDD-3D94-437F-92B6-BDD52507E49B"),
+                    Active = true,
+                    ActionTakenId = new Guid("51e5d358-f991-4574-a21b-79ccfa31ac9d"),   //Issued
+                    EventTypeId = new Guid("7AF4D45F-0C17-4231-9D0B-3971051B75E6"),   //PAF
+                },
+                new()
+                {
+                    Id = new Guid("A8A2C814-8F89-4726-B88F-40BBF205501B"),
+                    Active = true,
+                    ActionTakenId = new Guid("51e5d358-f991-4574-a21b-79ccfa31ac9d"),   //Issued
+                    EventTypeId = new Guid("43F184E5-0CD9-4C4B-B2C1-1F093076C60F"),   //PAF Invoice
                 }
             };
         }

--- a/tests/TestHelpers/SeedData/EventSeedData.cs
+++ b/tests/TestHelpers/SeedData/EventSeedData.cs
@@ -16,7 +16,7 @@ namespace FMS.TestData.SeedData
                 {
                     Id = new Guid("1105FB87-229E-417C-B0F5-3F1E70F1C66D"),
                     Active = true,
-                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),
+                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),   //WOODSTOCK CROSSING
                     ParentId = Guid.Empty,   //Self
                     EventTypeId = new Guid("F1A8BCAD-B09E-42BB-ABFD-74E230567A65"),   // HWTF Master Project
                     ActionTakenId = new Guid("0d7ee6cd-f975-40cf-94ff-406fe71075ff"),
@@ -32,7 +32,7 @@ namespace FMS.TestData.SeedData
                 {
                     Id = new Guid("E50B57D5-1929-4167-8ABD-22B82D7E8294"),
                     Active = true,
-                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),
+                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),  //WOODSTOCK CROSSING
                     ParentId = Guid.Empty,   //Self
                     EventTypeId = new Guid("F1A8BCAD-B09E-42BB-ABFD-74E230567A65"),   //HWTF Master Project
                     ActionTakenId = new Guid("634f379a-90b1-4762-9268-c0c278040723"),
@@ -48,8 +48,8 @@ namespace FMS.TestData.SeedData
                 {
                     Id = new Guid("271BA527-2624-49EB-9751-6E4E646A684E"),
                     Active = true,
-                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),
-                    ParentId = Guid.Empty,   //HWTF Master Project
+                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"), //WOODSTOCK CROSSING
+                    ParentId = new Guid("1105FB87-229E-417C-B0F5-3F1E70F1C66D"),   //HWTF Master Project
                     EventTypeId = new Guid("7AF4D45F-0C17-4231-9D0B-3971051B75E6"),   //PAF
                     ActionTakenId = new Guid("0d7ee6cd-f975-40cf-94ff-406fe71075ff"),
                     StartDate = new(2017, 1, 23),
@@ -64,8 +64,8 @@ namespace FMS.TestData.SeedData
                 {
                     Id = new Guid("261F8502-8382-4885-B53F-426A49655B17"),
                     Active = true,
-                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),
-                    ParentId = Guid.Empty,  //HWTF Master Project
+                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),  //WOODSTOCK CROSSING
+                    ParentId = new Guid("E50B57D5-1929-4167-8ABD-22B82D7E8294"),  //HWTF Master Project
                     EventTypeId = new Guid("7AF4D45F-0C17-4231-9D0B-3971051B75E6"),   //PAF
                     ActionTakenId = new Guid("51e5d358-f991-4574-a21b-79ccfa31ac9d"),
                     StartDate = new(2018, 2, 13),
@@ -80,7 +80,7 @@ namespace FMS.TestData.SeedData
                 {
                     Id = new Guid("027D8105-4F7E-42BB-8F12-B81AC790279B"),
                     Active = true,
-                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),
+                    FacilityId = new Guid("3A7457EC-E4A4-47D2-B47C-35078C3F5BF7"),  //WOODSTOCK CROSSING
                     ParentId = Guid.Empty,   //HWTF Master Project
                     EventTypeId = new Guid("867CAD56-D354-493A-A3CB-985101A5ACB7"),   //Finacial Assurance
                     ActionTakenId = new Guid("a7a3f7b3-8cd3-421c-a041-1f6a29cba42c"),


### PR DESCRIPTION
Corrects the event parent selection on the add event page.

The event list is now correctly filtered to show only "HWTF Master Project" events as parent options and the "None" option is correctly bound to Guid.Empty.

Also, ensures the event list on the add event page is grouped correctly.

Fixes #846