### PR TITLE
Persists new score details immediately

### DIFF
--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -89,6 +89,7 @@ namespace FMS.Infrastructure.Repositories
                 {
                     facility.ScoreDetails = new Score(facility.Id);
                     await _context.Scores.AddAsync(facility.ScoreDetails);
+                    await _context.SaveChangesAsync();
                 }
 
                 facility.Substances = await _context.Substances
@@ -110,6 +111,7 @@ namespace FMS.Infrastructure.Repositories
                 {
                     facility.GroundwaterScoreDetails = new GroundwaterScore(facility.Id);
                     await _context.GroundwaterScores.AddAsync(facility.GroundwaterScoreDetails);
+                    await _context.SaveChangesAsync();
                 }
 
                 facility.OnsiteScoreDetails = await _context.OnsiteScores
@@ -122,6 +124,7 @@ namespace FMS.Infrastructure.Repositories
                 {
                     facility.OnsiteScoreDetails = new OnsiteScore(facility.Id);
                     await _context.OnsiteScores.AddAsync(facility.OnsiteScoreDetails);
+                    await _context.SaveChangesAsync();
                 }
 
                 facility.StatusDetails = await _context.Statuses

--- a/tests/FMS.Infrastructure.Tests/EventRepositoryTest.cs
+++ b/tests/FMS.Infrastructure.Tests/EventRepositoryTest.cs
@@ -238,7 +238,7 @@ namespace FMS.Infrastructure.Tests
                 CompletionDate = new DateOnly(3, 3, 3),
                 ComplianceOfficerId = Guid.NewGuid(),
                 EventAmount = 0,
-                EntityNameOrNumber = "VALID_ENoN",
+                EventContractorId = Guid.NewGuid(),
                 Comment = "VALID_COMMENT",
             };
             _context.Events.Add(existingEvent);
@@ -257,7 +257,7 @@ namespace FMS.Infrastructure.Tests
                 CompletionDate = new DateOnly(30, 3, 30),
                 ComplianceOfficerId = Guid.NewGuid(),
                 EventAmount = 1,
-                EntityNameOrNumber = "NEW_ENoN",
+                EventContractorId = Guid.NewGuid(),
                 Comment = "NEW_COMMENT",
             };
             await _repository.UpdateEventAsync(updateDto);

--- a/tests/FMS.Infrastructure.Tests/OnsiteScoreRepositoryTest.cs
+++ b/tests/FMS.Infrastructure.Tests/OnsiteScoreRepositoryTest.cs
@@ -55,6 +55,7 @@ namespace FMS.Infrastructure.Tests
                 _context.Database.EnsureCreated();
                 _context.Dispose();
                 _repository.Dispose();
+                _substanceRepository.Dispose();
                 _disposed = true;
             }
         }
@@ -87,14 +88,14 @@ namespace FMS.Infrastructure.Tests
             result.FacilityId.Should().Be(existingOSS.FacilityId);
         }
 
-        //[Test]
-        //public async Task GetOnsiteScoreByIdAsync_WhenFacilityIdDoesNotExist_ReturnsNull()
-        //{
-        //    var nonExistingId = Guid.NewGuid();
-        //    var result = await _repository.GetOnsiteScoreByFacilityIdAsync(nonExistingId);
+        [Test]
+        public async Task GetOnsiteScoreByIdAsync_WhenFacilityIdDoesNotExist_ReturnsNull()
+        {
+            var nonExistingId = Guid.NewGuid();
+            var result = await _repository.GetOnsiteScoreByFacilityIdAsync(nonExistingId);
 
-        //    result.Should().BeNull();
-        //}
+            result.Should().BeNull();
+        }
 
         // CreateOnsiteScoreAsync
         [Test]


### PR DESCRIPTION
Ensures that newly created score details (Score,
GroundwaterScore, and OnsiteScore) are immediately saved to the database. This prevents potential data loss and inconsistencies.

Also, corrects Event update logic by using
EventContractorId instead of EntityNameOrNumber.

Finally, disposes of the SubstanceRepository in
OnsiteScoreRepositoryTest to prevent resource leaks.

Relates to #850