### PR TITLE
Remove Datadog Test Optimization from unit test workflow

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -29,12 +29,5 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
-      - name: Configure Datadog Test Optimization
-        uses: datadog/test-visibility-github-action@f4b026bb8b8b53f323960cf86a849a0231ff93b9
-        with:
-          languages: dotnet
-          api_key: ${{secrets.DD_API_KEY}}
-          site: us3.datadoghq.com
-
       - name: Test
         run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
We've decided not to use this product

This reverts commit 0430c8ea7a27f61ae5a993704f609c1d2e442916.
