### PR TITLE
Validates Postal Code format

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilityCreateDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityCreateDto.cs
@@ -59,8 +59,8 @@ namespace FMS.Domain.Dto
         public string State { get; set; }
 
         [Required]
-        [StringLength(10)]
         [Display(Name = "ZIP Code")]
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Invalid Zip Code format. Please enter a 5-digit number.")]
         [DataType(DataType.PostalCode)]
         public string PostalCode { get; set; }
 

--- a/FMS.Domain/Dto/Facility/FacilityEditDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityEditDto.cs
@@ -98,9 +98,8 @@ namespace FMS.Domain.Dto
         public string State { get; set; }
 
         [Required]
-        [StringLength(10)]
         [Display(Name = "ZIP Code")]
-        [DataType(DataType.PostalCode)]
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Invalid Zip Code format. Please enter a 5-digit number.")]
         public string PostalCode { get; set; }
 
         [Required]

--- a/FMS.Domain/Dto/Facility/FacilityMapSpec.cs
+++ b/FMS.Domain/Dto/Facility/FacilityMapSpec.cs
@@ -31,7 +31,7 @@ namespace FMS.Domain.Dto
         public string State { get; set; } = "Georgia";
 
         [Display(Name = "ZIP Code")]
-        [StringLength(10)]
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Invalid Zip Code format. Please enter a 5-digit number.")]
         public string PostalCode { get; set; }
 
         [Display(Name = "Latitude")]

--- a/FMS.Domain/Dto/Facility/FacilitySpec.cs
+++ b/FMS.Domain/Dto/Facility/FacilitySpec.cs
@@ -57,45 +57,45 @@ namespace FMS.Domain.Dto
         public string State { get; set; }
 
         [Display(Name = "ZIP Code")]
-        [StringLength(10)]
+        [RegularExpression(@"^\d{5}$", ErrorMessage = "Invalid Zip Code format. Please enter a 5-digit number.")]
         public string PostalCode { get; set; }
 
-        // The following properties only apply to Release Notifications
-        [Display(Name = "HSI Number")]
-        public string HSInumber { get; set; }
+        //// The following properties only apply to Release Notifications
+        //[Display(Name = "HSI Number")]
+        //public string HSInumber { get; set; }
 
-        [Display(Name = "Determination Letter Date")]
-        public DateOnly DeterminationLetterDate { get; set; }
+        //[Display(Name = "Determination Letter Date")]
+        //public DateOnly DeterminationLetterDate { get; set; }
 
-        [Display(Name = "Pre-RQSM Cleanup")]
-        public bool PreRQSMcleanup { get; set; }
+        //[Display(Name = "Pre-RQSM Cleanup")]
+        //public bool PreRQSMcleanup { get; set; }
 
-        [Display(Name = "Image Checked")]
-        public bool ImageChecked { get; set; }
+        //[Display(Name = "Image Checked")]
+        //public bool ImageChecked { get; set; }
 
-        [Display(Name = "Brownfield Deferral")]
-        public bool DeferredOnSiteScoring { get; set; }
+        //[Display(Name = "Brownfield Deferral")]
+        //public bool DeferredOnSiteScoring { get; set; }
 
-        [Display(Name = "Additional Data Requested")]
-        public bool AdditionalDataRequested { get; set; }
+        //[Display(Name = "Additional Data Requested")]
+        //public bool AdditionalDataRequested { get; set; }
 
-        [Display(Name = "VRP Deferral")]
-        public bool VRPReferral { get; set; }
+        //[Display(Name = "VRP Deferral")]
+        //public bool VRPReferral { get; set; }
 
-        [Display(Name = "Date Received")]
-        public DateOnly RNDateReceived { get; set; }
+        //[Display(Name = "Date Received")]
+        //public DateOnly RNDateReceived { get; set; }
 
-        [Display(Name = "Historical Unit")]
-        public string HistoricalUnit { get; set; }
+        //[Display(Name = "Historical Unit")]
+        //public string HistoricalUnit { get; set; }
 
-        [Display(Name = "Historical C.O.")]
-        public string HistoricalComplianceOfficer { get; set; }
+        //[Display(Name = "Historical C.O.")]
+        //public string HistoricalComplianceOfficer { get; set; }
 
-        [Display(Name = "Has Electronic Records")]
-        public bool HasERecord { get; set; }
+        //[Display(Name = "Has Electronic Records")]
+        //public bool HasERecord { get; set; }
 
-        [Display(Name = "General Comments for this Facility")]
-        public string Comments { get; set; }
+        //[Display(Name = "General Comments for this Facility")]
+        //public string Comments { get; set; }
 
         public IDictionary<string, string> AsRouteValues =>
             new Dictionary<string, string>
@@ -119,5 +119,16 @@ namespace FMS.Domain.Dto
                 {nameof(ShowPendingOnly), ShowPendingOnly.ToString()},
                 {nameof(FirstPass), FirstPass.ToString()},
             };
+
+        public void TrimAll()
+        {
+            FileLabel = FileLabel?.Trim();
+            FacilityNumber = FacilityNumber?.Trim();
+            Name = Name?.Trim();
+            Location = Location?.Trim();
+            Address = Address?.Trim();
+            City = City?.Trim();
+            PostalCode = PostalCode?.Trim();
+        }
     }
 }

--- a/FMS/Pages/Contact/Add.cshtml.cs
+++ b/FMS/Pages/Contact/Add.cshtml.cs
@@ -39,9 +39,6 @@ namespace FMS.Pages.Contact
 
         public static SelectList States => new(Data.States);
 
-        [BindProperty(SupportsGet = true)]
-        public Guid Id { get; set; }
-
         [TempData]
         public string ActiveTab { get; set; }
 

--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -72,7 +72,7 @@ namespace FMS.Pages.Facilities
 
         public async Task<IActionResult> OnGetSearchAsync(FacilitySpec spec, [FromQuery] int p = 1)
         {
-            
+            spec.TrimAll();
             // Sort by Received Date for Pending Release Notifications
             if (spec.ShowPendingOnly && spec.FirstPass) 
             {

--- a/FMS/Pages/Facilities/Map.cshtml
+++ b/FMS/Pages/Facilities/Map.cshtml
@@ -31,6 +31,7 @@
                 <label asp-for="Spec.Address"></label>
                 <input id="Address" asp-for="Spec.Address" class="form-control" />
                 <input id="LocalAddress" asp-for="Spec.GeocodeAddress" type="hidden" />
+                <span asp-validation-for="Spec.Address" class="text-danger"></span>
             </div>
             <div class="col-md-4">
                 <label asp-for="Spec.FacilityTypeId"></label>
@@ -51,6 +52,7 @@
             <div class="col">
                 <label asp-for="Spec.PostalCode"></label>
                 <input id="PostalCode" asp-for="Spec.PostalCode" class="form-control" />
+                <span asp-validation-for="Spec.PostalCode" class="text-danger"></span>
             </div>
         </div>
         <div class="mb-3 row">

--- a/FMS/Pages/Facilities/Map.cshtml.cs
+++ b/FMS/Pages/Facilities/Map.cshtml.cs
@@ -66,6 +66,11 @@ namespace FMS.Pages.Facilities
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Critical Code Smell", "S3776:Cognitive Complexity of methods should not be too high", Justification = "<Pending>")]
         public async Task<IActionResult> OnGetSearchAsync(FacilityMapSpec spec)
         {
+            if (!ModelState.IsValid)
+            {
+                await PopulateSelectsAsync();
+                return Page();
+            }
             // Make sure GeoCoordinates are withing the State of Georgia or both Zero
             GeoCoordHelper.CoordinateValidation EnumVal = GeoCoordHelper.ValidateCoordinatesMap(spec.Latitude, spec.Longitude);
             string ValidationString = GeoCoordHelper.GetDescription(EnumVal);


### PR DESCRIPTION
Adds regular expression validation to Postal Code fields in Facility DTOs to ensure a 5-digit format. Removes unnecessary StringLength attributes and comments out unused properties in FacilitySpec.

Also, implements a TrimAll method to remove whitespace from search parameters and applies it on the Facilities Index page.
Adds validation to the Map search page to re-populate selects and return to the page if invalid.

Fixes #868
Fixes #843