### PR TITLE
Cleans up and organizes assignment report code.

### DIFF
--- a/FMS.Domain/Dto/Reports/AssignmentListReportByCODto.cs
+++ b/FMS.Domain/Dto/Reports/AssignmentListReportByCODto.cs
@@ -1,11 +1,5 @@
 ﻿using ClosedXML.Attributes;
 using FMS.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FMS.Domain.Dto
 {
@@ -15,7 +9,7 @@ namespace FMS.Domain.Dto
 
         public AssignmentListReportByCODto(Facility facility)
         {
-            ComplianceOfficer =facility.ComplianceOfficer?.Name;
+            ComplianceOfficer = facility.ComplianceOfficer?.Name;
             FacilityNumber = facility.FacilityNumber;
             FacilityName = facility.Name;
             FacilityStatusName = facility.FacilityStatus?.Name;

--- a/FMS.Domain/Dto/Reports/AssignmentListReportByCountyDto.cs
+++ b/FMS.Domain/Dto/Reports/AssignmentListReportByCountyDto.cs
@@ -1,11 +1,5 @@
 ﻿using ClosedXML.Attributes;
 using FMS.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FMS.Domain.Dto
 {

--- a/FMS.Domain/Dto/Reports/AssignmentListReportByHSIDto.cs
+++ b/FMS.Domain/Dto/Reports/AssignmentListReportByHSIDto.cs
@@ -1,11 +1,5 @@
 ﻿using ClosedXML.Attributes;
 using FMS.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FMS.Domain.Dto
 {

--- a/FMS.Domain/Dto/Reports/AssignmentListReportBySiteNameDto.cs
+++ b/FMS.Domain/Dto/Reports/AssignmentListReportBySiteNameDto.cs
@@ -1,11 +1,5 @@
 ﻿using ClosedXML.Attributes;
 using FMS.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FMS.Domain.Dto
 {
@@ -38,7 +32,7 @@ namespace FMS.Domain.Dto
         [XLColumn(Header = "C.O.")]
         public string ComplianceOfficerName { get; set; }
 
-        [XLColumn(Header = "HSRA Buddy Unit")]
+        [XLColumn(Header = "HSRA Unit")]
         public string OrganizationalUnitName { get; set; }
     }
 }

--- a/FMS.Domain/Dto/Reports/AssignmentListReportByUnitDto.cs
+++ b/FMS.Domain/Dto/Reports/AssignmentListReportByUnitDto.cs
@@ -1,11 +1,5 @@
 ﻿using ClosedXML.Attributes;
 using FMS.Domain.Entities;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FMS.Domain.Dto
 {

--- a/FMS.Domain/Repositories/IReportingRepository.cs
+++ b/FMS.Domain/Repositories/IReportingRepository.cs
@@ -1,14 +1,13 @@
 ﻿using FMS.Domain.Dto;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace FMS.Domain.Repositories
 {
     public interface IReportingRepository : IDisposable
     {
+        #region Asignment Reports
         Task<IReadOnlyList<AssignmentListReportByCODto>> GetAsignmentListByCOAsync();
 
         Task<IReadOnlyList<AssignmentListReportByCountyDto>> GetAsignmentListByCountyAsync();
@@ -18,5 +17,14 @@ namespace FMS.Domain.Repositories
         Task<IReadOnlyList<AssignmentListReportBySiteNameDto>> GetAsignmentListBySiteNameAsync();
 
         Task<IReadOnlyList<AssignmentListReportByUnitDto>> GetAsignmentListByUnitAsync();
+        #endregion
+
+        #region Delisted Reports
+
+        #endregion
+
+        #region Events Reports
+
+        #endregion
     }
 }

--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace FMS.Infrastructure.Repositories
@@ -15,6 +14,7 @@ namespace FMS.Infrastructure.Repositories
         private readonly FmsDbContext _context;
         public ReportingRepository(FmsDbContext context) => _context = context;
 
+        #region Assignment Reports
         public async Task<IReadOnlyList<AssignmentListReportByCODto>> GetAsignmentListByCOAsync()
         {
             var facilityList = await _context.Facilities.AsNoTracking()
@@ -126,6 +126,15 @@ namespace FMS.Infrastructure.Repositories
 
             return reportDto;
         }
+        #endregion
+
+        #region Delisted Reports
+
+        #endregion
+
+        #region Events Reports
+
+        #endregion
 
         #region IDisposable Support
 


### PR DESCRIPTION
Removes unused namespaces from DTOs for assignment reports. Renames "HSRA Buddy Unit" column to "HSRA Unit" in the AssignmentListReportBySiteNameDto.
Adds regions to the reporting repository and interface for better code organization.