### PR TITLE
Adds HSI Site List Reports feature

### DIFF
--- a/FMS.Domain/Dto/Reports/HSIListReportDto.cs
+++ b/FMS.Domain/Dto/Reports/HSIListReportDto.cs
@@ -1,0 +1,34 @@
+﻿using ClosedXML.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FMS.Domain.Dto.Reports
+{
+    public enum HSISortBy
+    {
+        HSINumber,
+        Name,
+        County,
+        ClassName
+    }
+       
+    public class HSIListReportDto
+    {
+        public HSIListReportDto() { }
+
+        [XLColumn(Header ="HSI Number")]
+        public string HSINumber { get; set; }
+
+        [XLColumn(Header ="Facility Name")]
+        public string Name { get; set; }
+
+        [XLColumn(Header ="County")]
+        public string County { get; set; }
+
+        [XLColumn(Header ="Class")]
+        public string ClassName { get; set; }
+    }
+}

--- a/FMS.Domain/Repositories/IReportingRepository.cs
+++ b/FMS.Domain/Repositories/IReportingRepository.cs
@@ -1,4 +1,5 @@
 ﻿using FMS.Domain.Dto;
+using FMS.Domain.Dto.Reports;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -38,6 +39,12 @@ namespace FMS.Domain.Repositories
         #region PAF Report
 
         Task<IReadOnlyList<PAFReportRawDto>> GetPAFReportAsync();
+
+        #endregion
+
+        #region HSI ListReports
+
+        Task<IReadOnlyList<HSIListReportDto>> GetHSIListReportAsync(HSISortBy sortBy);
 
         #endregion
     }

--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -3,6 +3,7 @@ using DocumentFormat.OpenXml.InkML;
 using DocumentFormat.OpenXml.Office2010.Excel;
 using FMS;
 using FMS.Domain.Dto;
+using FMS.Domain.Dto.Reports;
 using FMS.Domain.Entities;
 using FMS.Domain.Repositories;
 using FMS.Infrastructure.Contexts;
@@ -264,6 +265,53 @@ namespace FMS.Infrastructure.Repositories
 
             return (await conn.QueryAsync<PAFReportRawDto>("dbo.PAF_Report", commandType: CommandType.StoredProcedure)).ToList();
         }
+
+        #endregion
+
+        #region HSI List Reports
+
+        public async Task<IReadOnlyList<HSIListReportDto>> GetHSIListReportAsync(HSISortBy sortBy)
+        {
+            var facilityList = await _context.Facilities.AsNoTracking()
+                .Include(e => e.FacilityType)
+                .Include(e => e.LocationDetails)
+                .Include(e => e.LocationDetails.LocationClass)
+                .Include(e => e.County)
+                .Where(e => e.FacilityType.Name == "HSI")
+                .Select(e => new HSIListReportDto()
+                {
+                    HSINumber = e.FacilityNumber,
+                    Name = e.Name,
+                    County = e.County.Name,
+                    ClassName = e.LocationDetails.LocationClass.Name
+                })
+                .ToListAsync();
+
+            return OrderHSIReportQuery(facilityList, sortBy);
+        }
+
+        private static IReadOnlyList<HSIListReportDto> OrderHSIReportQuery(
+            IList<HSIListReportDto> facilityList, HSISortBy sortBy) =>
+            sortBy switch
+            {
+                HSISortBy.HSINumber => facilityList
+                    .OrderBy(e => e.HSINumber)
+                    .ToList(),
+                HSISortBy.Name => facilityList
+                    .OrderBy(e => e.Name)
+                    .ToList(),
+                HSISortBy.County => facilityList
+                    .OrderBy(e => e.County)
+                    .ThenBy(e => e.HSINumber)
+                    .ToList(),
+                HSISortBy.ClassName => facilityList
+                    .OrderBy(e => e.ClassName)
+                    .ThenBy(e => e.HSINumber)
+                    .ToList(),
+                _ => facilityList
+                    .OrderBy(e => e.Name)
+                    .ToList()
+            };
 
         #endregion
 

--- a/FMS/Helpers/ExportHelper.cs
+++ b/FMS/Helpers/ExportHelper.cs
@@ -28,7 +28,11 @@ namespace FMS
             EventCompleted,
             EventCompletedOutstanding,
             EventNoActionTaken,
-            PAF
+            PAF,
+            HSIListByNumber,
+            HSIListByName,
+            HSIListByCounty,
+            HSIListByClass
         }
 
         /// <summary>
@@ -342,6 +346,54 @@ namespace FMS
                 table.ShowAutoFilter = true;
                 // Must enable the filter
                 table.AutoFilter.IsEnabled = true;
+            }
+
+            if(reportType == ReportType.HSIListByNumber)
+            {
+                ws = wb.AddWorksheet("HSI List");
+                table = ws.Cell(2, 1).InsertTable(list);
+                table.ShowHeaderRow = true;
+
+                ws.Columns().AdjustToContents(1, 10000);
+                ws.Cell("B1").Style.Font.Bold = true;
+                ws.Cell("B1").Style.Font.FontSize = 14;
+                ws.Cell("B1").Value = "HSI List By Facility Number";
+            }
+
+            if (reportType == ReportType.HSIListByName)
+            {
+                ws = wb.AddWorksheet("HSI List");
+                table = ws.Cell(2, 1).InsertTable(list);
+                table.ShowHeaderRow = true;
+
+                ws.Columns().AdjustToContents(1, 10000);
+                ws.Cell("B1").Style.Font.Bold = true;
+                ws.Cell("B1").Style.Font.FontSize = 14;
+                ws.Cell("B1").Value = "HSI List By Facility Name";
+            }
+
+            if (reportType == ReportType.HSIListByCounty)
+            {
+                ws = wb.AddWorksheet("HSI List");
+                table = ws.Cell(2, 1).InsertTable(list);
+                table.ShowHeaderRow = true;
+
+                ws.Columns().AdjustToContents(1, 10000);
+                ws.Cell("B1").Style.Font.Bold = true;
+                ws.Cell("B1").Style.Font.FontSize = 14;
+                ws.Cell("B1").Value = "HSI List By County";
+            }
+
+            if (reportType == ReportType.HSIListByClass)
+            {
+                ws = wb.AddWorksheet("HSI List");
+                table = ws.Cell(2, 1).InsertTable(list);
+                table.ShowHeaderRow = true;
+
+                ws.Columns().AdjustToContents(1, 10000);
+                ws.Cell("B1").Style.Font.Bold = true;
+                ws.Cell("B1").Style.Font.FontSize = 14;
+                ws.Cell("B1").Value = "HSI List By Class";
             }
 
             wb.SaveAs(ms);

--- a/FMS/Pages/Reporting/HSISiteLists/Index.cshtml
+++ b/FMS/Pages/Reporting/HSISiteLists/Index.cshtml
@@ -8,4 +8,49 @@
 <h1>@ViewData["Title"]</h1>
 <a asp-page="../Index">← Back to Reports</a>
 <hr />
-<h2><i>Under Construction</i></h2>
+<p class="lead">Select a Report from the list</p>
+<form method="post">
+    <div class="row">
+        <div class="col-md-4">
+            <button id="ByNumber"
+                    asp-page-handler="ByNumber"
+                    class="btn btn-sm btn-outline-primary mb-1">
+                Report
+            </button>
+            HSI List By Number
+        </div>
+    </div>
+    <br />
+    <div class="row">
+        <div class="col-md-4">
+            <button id="ByName"
+                    asp-page-handler="ByName"
+                    class="btn btn-sm btn-outline-primary mb-1">
+                Report
+            </button>
+            HSI List By Name
+        </div>
+    </div>
+    <br />
+    <div class="row">
+        <div class="col-md-4">
+            <button id="ByCounty"
+                    asp-page-handler="ByCounty"
+                    class="btn btn-sm btn-outline-primary mb-1">
+                Report
+            </button>
+            HSI List By County
+        </div>
+    </div>
+    <br />
+    <div class="row">
+        <div class="col-md-4">
+            <button id="ByClass"
+                    asp-page-handler="ByClass"
+                    class="btn btn-sm btn-outline-primary mb-1">
+                Report
+            </button>
+            HSI List By Class
+        </div>
+    </div>
+</form>

--- a/FMS/Pages/Reporting/HSISiteLists/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/HSISiteLists/Index.cshtml.cs
@@ -1,12 +1,69 @@
+using FMS.Domain.Dto;
+using FMS.Domain.Dto.Reports;
+using FMS.Domain.Repositories;
+using FMS.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace FMS.Pages.Reporting.HSISiteLists
 {
     public class IndexModel : PageModel
     {
+        private readonly IReportingRepository _repository;
+
+        public IndexModel(IReportingRepository repository) => _repository = repository;
+
         public void OnGet()
         {
+            // Method intentionally left empty.
+        }
+
+        public async Task<IActionResult> OnPostByNumberAsync() 
+        {
+            var fileName = $"HSI_Sites_By_Number_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
+
+            // "eventsPendingList" List to go to a report
+            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.HSINumber);
+
+            // Export to Excel
+            return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByNumber), "application/vnd.ms-excel", fileName);
+        }
+
+        public async Task<IActionResult> OnPostByNameAsync()
+        {
+            var fileName = $"HSI_Sites_By_Name_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
+
+            // "eventsPendingList" List to go to a report
+            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.Name);
+
+            // Export to Excel
+            return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByName), "application/vnd.ms-excel", fileName);
+        }
+
+        public async Task<IActionResult> OnPostByCountyAsync()
+        {
+            var fileName = $"HSI_Sites_By_County_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
+
+            // "eventsPendingList" List to go to a report
+            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.County);
+
+            // Export to Excel
+            return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByCounty), "application/vnd.ms-excel", fileName);
+        }
+
+        public async Task<IActionResult> OnPostByClassAsync()
+        {
+            var fileName = $"HSI_Sites_By_Class_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
+
+            // "eventsPendingList" List to go to a report
+            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.ClassName);
+
+            // Export to Excel
+            return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByClass), "application/vnd.ms-excel", fileName);
         }
     }
 }

--- a/FMS/Pages/Reporting/Index.cshtml
+++ b/FMS/Pages/Reporting/Index.cshtml
@@ -22,7 +22,7 @@
         <a class="nav-link" asp-page="PAF/Index">@ReportingOptions.PAF</a>
     </li>
     <li>
-        <a class="nav-link" asp-page="HSISiteLists/Index">@ReportingOptions.HSISiteLists <span class="text-danger">*<i> Under Construction</i></span></a>
+        <a class="nav-link" asp-page="HSISiteLists/Index">@ReportingOptions.HSISiteLists</a>
     </li>
     <li>
         <a class="nav-link" asp-page="AbndInac/Index">@ReportingOptions.AbndInac <span class="text-danger">*<i> Under Construction</i></span></a>


### PR DESCRIPTION
Implements the HSI Site List Reports feature, enabling users to generate reports listing HSI sites sorted by various criteria (Number, Name, County, Class).

Includes:
- Data transfer object (DTO) for HSI list reports
- Repository method to retrieve HSI list data
- User interface for report selection and generation
- Excel export functionality for different report types