### PR TITLE
Enhances PAF report with summary totals and counts

### DIFF
--- a/FMS/Helpers/ExportHelper.cs
+++ b/FMS/Helpers/ExportHelper.cs
@@ -1,13 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using ClosedXML.Excel;
+using DocumentFormat.OpenXml.Spreadsheet;
 using FMS.Domain.Dto;
 using FMS.Domain.Services;
 using Spire.Pdf;
 using Spire.Pdf.Fields;
 using Spire.Pdf.Widget;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 
 namespace FMS
 {
@@ -386,14 +387,13 @@ namespace FMS
                 table = ws.Cell(2, 1).InsertTable(list);
                 table.ShowHeaderRow = true;
 
-                ws.Columns().AdjustToContents(1, 10000);
                 ws.Cell("D1").Style.Font.Bold = true;
                 ws.Cell("D1").Style.Font.FontSize = 14;
                 ws.Cell("D1").Value = "PAF Report";
                 ws.Column("C").Style.DateFormat.Format = "MM/dd/yyyy";
                 ws.Column("D").Style.NumberFormat.NumberFormatId = (int)XLPredefinedFormat.Number.Precision2;
                 ws.Column("G").Style.DateFormat.Format = "MM/dd/yyyy";
-                ws.Column("H").Style.DateFormat.SetFormat(ClosedXML.Excel.XLDateTimeGrouping.Month.ToString());
+                ws.Column("H").Style.DateFormat.Format = "MM/dd/yyyy";
                 ws.Column("I").Style.DateFormat.Format = "MM/dd/yyyy";
                 ws.Column("J").Style.DateFormat.Format = "MM/dd/yyyy";
                 ws.Column("K").Style.DateFormat.Format = "MM/dd/yyyy";
@@ -402,6 +402,32 @@ namespace FMS
                 table.ShowAutoFilter = true;
                 // Must enable the filter
                 table.AutoFilter.IsEnabled = true;
+                table.ShowTotalsRow = true;
+
+                // *************** Report Totals ***************
+                table.Field("PAF Issue Date").TotalsCell.Value = "Total PAF Amt -->";
+                // PAF Amount Sum
+                table.Field("PAF Amount").TotalsRowFunction = XLTotalsRowFunction.Sum;
+
+                // Number of Unique Compliance Officers
+                IXLColumn columnPO = ws.Column("E");
+                // Extract the non-empty cell values and convert them to a list of strings
+                var cellValues = columnPO.CellsUsed().Select(cell => cell.GetString()).ToList();
+                // Use LINQ to count the unique items
+                int uniqueCount = cellValues.Distinct().Count();
+                table.Field("Project Officer").TotalsCell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                table.Field("Project Officer").TotalsCell.Value = "Count " + uniqueCount.ToString();
+
+                // Number of Unique Contractors
+                IXLColumn columnCont = ws.Column("F");
+                // Extract the non-empty cell values and convert them to a list of strings
+                var cellValuesCont = columnCont.CellsUsed().Select(cell => cell.GetString()).ToList();
+                // Use LINQ to count the unique items
+                int uniqueCountCont = cellValuesCont.Distinct().Count();
+                table.Field("Contractor").TotalsCell.Style.Alignment.Horizontal = XLAlignmentHorizontalValues.Center;
+                table.Field("Contractor").TotalsCell.Value = "Count " + uniqueCountCont.ToString();
+
+                ws.Columns().AdjustToContents(1, 10000);
             }
 
             if(reportType == ReportType.HSIListByNumber)

--- a/FMS/Pages/Reporting/PAF/Index.cshtml
+++ b/FMS/Pages/Reporting/PAF/Index.cshtml
@@ -62,9 +62,27 @@
                             <td>@p.RARApproved</td>
                             <td>@p.ProjectCompleteDue</td>
                             <td>@p.ProjectCompleteActual</td>
-                            <td>@p.ProjectComments</td>
+                            <td>@(p.ProjectComments.Length > 50 ? p.ProjectComments.Substring(0, 50) : p.ProjectComments)</td>
                         </tr>
                     }
+                    <hr />
+                    <tr>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td>Total Amt&#8681;<br />$@Model.PAFAmtTotal</td>
+                        <td class="text-center">P.O.s&#8681;<br />@Model.UniqueCO</td>
+                        <td class="text-center">Contractors&#8681;<br />@Model.UniqueContractor</td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                        <td></td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/FMS/Pages/Reporting/PAF/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/PAF/Index.cshtml.cs
@@ -1,3 +1,4 @@
+using ClosedXML.Excel;
 using FMS.Domain.Dto;
 using FMS.Domain.Repositories;
 using FMS.Platform.Extensions;
@@ -20,6 +21,12 @@ namespace FMS.Pages.Reporting.PAF
 
         public IList<PAFReportDto> PAFReport { get; set; }
 
+        public decimal? PAFAmtTotal { get; set; } = 0;
+
+        public int UniqueCO { get; set; }
+
+        public int UniqueContractor { get; set; }
+
         public DisplayMessage DisplayMessage { get; private set; }
 
         public async Task<IActionResult> OnGetAsync()
@@ -29,6 +36,24 @@ namespace FMS.Pages.Reporting.PAF
                 PAFReportRaw = await _repository.GetPAFReportAsync();
                 // Map to PAFReportDto
                 PAFReport = PAFReportRaw.Select(raw => new PAFReportDto(raw)).ToList();
+
+                // Get Column Totals
+                IList<string> COList = [];
+                IList<string> ContractorList = [];
+                foreach (var p in PAFReport)
+                {
+                    PAFAmtTotal = PAFAmtTotal + p.PAFAmount;
+                    if(!COList.Contains(p.ProjectOfficer))
+                    {
+                        COList.Add(p.ProjectOfficer);
+                    }
+                    if(!ContractorList.Contains(p.Contractor))
+                    {
+                        ContractorList.Add(p.Contractor);
+                    }
+                }
+                UniqueCO = COList.Distinct().Count();
+                UniqueContractor = ContractorList.Distinct().Count();
 
                 TempData?.SetDisplayMessage(Context.Success, "Successfully Loaded PAF Report");
                 DisplayMessage = TempData?.GetDisplayMessage();


### PR DESCRIPTION
Introduces a summary row to the PAF report on the web page, displaying the total PAF amount, unique project officer count, and unique contractor count.

Adds comprehensive totals and unique counts for PAF amounts, project officers, and contractors directly into the Excel export, improving report analysis.

Corrects the 'RAR Approved' date format in the Excel export to display the full `MM/dd/yyyy` date for consistency. Truncates long project comments on the web page for improved readability and layout.

Relates to #988