### PR TITLE
Refactors Google Maps URL generation into URLHelper

### DIFF
--- a/FMS/Helpers/URLHelper.cs
+++ b/FMS/Helpers/URLHelper.cs
@@ -1,4 +1,5 @@
-﻿using FMS.Platform.Extensions;
+﻿using FMS.Domain.Dto;
+using FMS.Platform.Extensions;
 using Microsoft.IdentityModel.Tokens;
 
 namespace FMS.Helpers
@@ -45,6 +46,15 @@ namespace FMS.Helpers
         {
             var link = string.Concat(GlobalConstants.MapCoordLink, lat.ToString(), ",", lon.ToString());
             return link;
+        }
+
+        public string GetGoogleMapsUrlLink(decimal? lat, decimal? lon, string mapZoom, string mapType)
+        {
+            if (lat != 0 && lon != 0)
+            {
+                return $"https://maps.googleapis.com/maps/api/staticmap?center={lat},{lon}&zoom={mapZoom}&size=250x250&markers=size:small|color:red|{lat},{lon}&maptype={mapType}&key={GoogleMapsApiKey}&style=feature:poi|visibility:off";
+            }
+            return null;
         }
     }
 }

--- a/FMS/Pages/Facilities/Details.cshtml.cs
+++ b/FMS/Pages/Facilities/Details.cshtml.cs
@@ -190,11 +190,7 @@ namespace FMS.Pages.Facilities
 
         public string GetGoogleMapsUrl(FacilityDetailDto facility)
         {
-            if (facility.Latitude != 0 && facility.Longitude != 0)
-            {
-                return $"https://maps.googleapis.com/maps/api/staticmap?center={facility.Latitude},{facility.Longitude}&zoom={facility.LocationDetails.MapZoom}&size=250x250&markers=color:red%7C{facility.Latitude},{facility.Longitude}&maptype={facility.LocationDetails.MapType}&key={GoogleMapsApiKey}&style=feature:poi|visibility:off";
-            }
-            return null;
+            return new UrlHelper(_configuration).GetGoogleMapsUrlLink(facility.Latitude, facility.Longitude, facility.LocationDetails.MapZoom, facility.LocationDetails.MapType);
         }
     }
 }

--- a/FMS/Pages/Location/Edit.cshtml.cs
+++ b/FMS/Pages/Location/Edit.cshtml.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
 using System.Threading.Tasks;
+using FMS.Helpers;
 
 namespace FMS.Pages.Location
 {
@@ -122,11 +123,7 @@ namespace FMS.Pages.Location
         }
         public string GetGoogleMapsUrl(FacilityDetailDto facility)
         {
-            if (facility.Latitude != 0 && facility.Longitude != 0)
-            {
-                return $"https://maps.googleapis.com/maps/api/staticmap?center={facility.Latitude},{facility.Longitude}&zoom={Location.MapZoom}&size=250x250&markers=color:red%7C{facility.Latitude},{facility.Longitude}&maptype={Location.MapType}&key={GoogleMapsApiKey}&style=feature:poi|visibility:off";
-            }
-            return null;
+            return new UrlHelper(_configuration).GetGoogleMapsUrlLink(facility.Latitude, facility.Longitude, facility.LocationDetails.MapZoom, facility.LocationDetails.MapType);
         }
     }
 }

--- a/FMS/Pages/Reporting/SiteSummary/Report.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Report.cshtml.cs
@@ -39,11 +39,7 @@ namespace FMS.Pages.Reporting.SiteSummary
 
         public string GetGoogleMapsUrl(SiteSummaryReportDto facility)
         {
-            if (facility.Latitude != 0 && facility.Longitude != 0)
-            {
-                return $"https://maps.googleapis.com/maps/api/staticmap?center={facility.Latitude},{facility.Longitude}&zoom={facility.LocationDetails.MapZoom}&size=250x250&markers=color:red%7C{facility.Latitude},{facility.Longitude}&maptype={facility.LocationDetails.MapType}&key={GoogleMapsApiKey}&style=feature:poi|visibility:off";
-            }
-            return null;
+            return new UrlHelper(_configuration).GetGoogleMapsUrlLink(facility.Latitude, facility.Longitude, facility.LocationDetails.MapZoom, facility.LocationDetails.MapType);
         }
 
         public string GetStatusLanguage(SiteSummaryReportDto facility) => SiteSummaryHelper.GetCleanupStatusLanguage(facility);


### PR DESCRIPTION
Centralizes the logic for generating Google Maps static map URLs into a reusable helper method, reducing code duplication across the Facilities, Location, and Reporting pages.

Fixes #1000