### PR TITLE
Updates postal code validation for US and Canadian formats

### DIFF
--- a/FMS.Domain/Dto/Contact/ContactCreateDto.cs
+++ b/FMS.Domain/Dto/Contact/ContactCreateDto.cs
@@ -36,7 +36,7 @@ namespace FMS.Domain.Dto
         [Display(Name = "State")]
         public string State { get; set; }
 
-        [RegularExpression(@"(^\\d{5}(-\\d{4})?$)|([ABCEGHJ-NPRSTVXY][0-9][ABCEGHJ-NPRSTV-Z] ?[0-9][ABCEGHJ-NPRSTV-Z][0-9]$)", ErrorMessage = "Invalid format. Please enter a valid US or Canadian Postal Code.")]
+        [RegularExpression(@"^(\d{5}(-\d{4})?|[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ] ?\d[ABCEGHJKLMNPRSTVWXYZ]\d)$", ErrorMessage = "Invalid format. Please enter a valid US or Canadian Postal Code.")]
         [Display(Name = "Postal(ZIP) Code")]
         public string PostalCode { get; set; }
 

--- a/FMS.Domain/Dto/Contact/ContactEditDto.cs
+++ b/FMS.Domain/Dto/Contact/ContactEditDto.cs
@@ -56,7 +56,7 @@ namespace FMS.Domain.Dto
         [Display(Name = "State")]
         public string State { get; set; }
 
-        [RegularExpression(@"(^\\d{5}(-\\d{4})?$)|([ABCEGHJ-NPRSTVXY][0-9][ABCEGHJ-NPRSTV-Z] ?[0-9][ABCEGHJ-NPRSTV-Z][0-9]$)", ErrorMessage = "Invalid format. Please enter a valid US or Canadian Postal Code.")]
+        [RegularExpression(@"^(\d{5}(-\d{4})?|[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJKLMNPRSTVWXYZ] ?\d[ABCEGHJKLMNPRSTVWXYZ]\d)$", ErrorMessage = "Invalid format. Please enter a valid US or Canadian Postal Code.")]
         [Display(Name = "Postal(ZIP) Code")]
         public string PostalCode { get; set; }
 

--- a/FMS/Pages/Contact/Add.cshtml
+++ b/FMS/Pages/Contact/Add.cshtml
@@ -72,6 +72,7 @@
             <div class="col-md-3">
                 <label asp-for="NewContact.PostalCode"></label>
                 <input asp-for="NewContact.PostalCode" class="form-control" />
+                <span class="text-danger"><small>Canadian must be uppercase</small></span>
                 <span asp-validation-for="NewContact.PostalCode" class="text-danger"></span>
             </div>
         </div>

--- a/FMS/Pages/Contact/Edit.cshtml
+++ b/FMS/Pages/Contact/Edit.cshtml
@@ -71,6 +71,7 @@
             <div class="col-md-3">
                 <label asp-for="EditContact.PostalCode"></label>
                 <input asp-for="EditContact.PostalCode" class="form-control" />
+                <span class="text-danger"><small>Canadian must be uppercase</small></span>
                 <span asp-validation-for="EditContact.PostalCode" class="text-danger"></span>
             </div>
         </div>


### PR DESCRIPTION
Corrects the regular expression used for validating postal codes in contact DTOs and adds a UI label indicating that Canadian codes must be uppercase.

Fixes #1006