### PR TITLE
Adds validation for Brownfield and VRP termination dates

### DIFF
--- a/FMS/Pages/HsrpFacilityProperties/Edit.cshtml
+++ b/FMS/Pages/HsrpFacilityProperties/Edit.cshtml
@@ -42,40 +42,42 @@
             </div>
         </div>
         <div class="row mb-3">
-            <div class="col mb-3">
+            <div class="col-4 mb-3">
                 <label asp-for="HsrpFacilityProperties.BrownfieldDate" class="form-label"></label>
                 <input asp-for="HsrpFacilityProperties.BrownfieldDate" class="form-control datepicker" type="date" placeholder="" />
                 <span asp-validation-for="HsrpFacilityProperties.BrownfieldDate" class="text-danger"></span>
             </div>
-            <div class="col mb-3">
-                <input asp-for="HsrpFacilityProperties.BrownfieldTerminated" class="form-check-input" />
-                <label asp-for="HsrpFacilityProperties.BrownfieldTerminated" class="form-check-label"></label>
-                <span asp-validation-for="HsrpFacilityProperties.BrownfieldTerminated" class="text-danger"></span>
-            </div>
-            <div class="col mb-3">
+            <div class="col-4 mb-3">
                 <label asp-for="HsrpFacilityProperties.VRPDate" class="form-label"></label>
                 <input asp-for="HsrpFacilityProperties.VRPDate" class="form-control datepicker" type="date" placeholder="" />
                 <span asp-validation-for="HsrpFacilityProperties.VRPDate" class="text-danger"></span>
             </div>
-            <div class="col mb-3">
-                <input asp-for="HsrpFacilityProperties.VRPTerminated" class="form-check-input" />
-                <label asp-for="HsrpFacilityProperties.VRPTerminated" class="form-check-label"></label>
-                <span asp-validation-for="HsrpFacilityProperties.VRPTerminated" class="text-danger"></span>
-            </div>
-            <div class="col mb-3">
+            <div class="col-4 mb-3">
                 <label asp-for="HsrpFacilityProperties.DateDeListed" class="form-label"></label>
                 <input asp-for="HsrpFacilityProperties.DateDeListed" class="form-control datepicker" type="date" placeholder="" />
                 <span asp-validation-for="HsrpFacilityProperties.DateDeListed" class="text-danger"></span>
             </div>
         </div>
+        <div class="row mb-3">
+            <div class="col-4 mb-3">
+                <input asp-for="HsrpFacilityProperties.BrownfieldTerminated" class="form-check-input" />
+                <label asp-for="HsrpFacilityProperties.BrownfieldTerminated" class="form-check-label"></label><br/>
+                <span asp-validation-for="HsrpFacilityProperties.BrownfieldTerminated" class="text-danger"></span>
+            </div>
+            <div class="col-4 mb-3">
+                <input asp-for="HsrpFacilityProperties.VRPTerminated" class="form-check-input" />
+                <label asp-for="HsrpFacilityProperties.VRPTerminated" class="form-check-label"></label><br/>
+                <span asp-validation-for="HsrpFacilityProperties.VRPTerminated" class="text-danger"></span>
+            </div>
+        </div>
         <hr />
         <div class="row mb-3">
             <button id="SubmitButton" type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Update</button>
-            <a asp-page="../Facilities/Details" 
-                asp-route-id="@Model.Facility.Id"
+            <a asp-page="../Facilities/Details"
+               asp-route-id="@Model.Facility.Id"
                asp-route-tab="HSIProperties"
                asp-fragment="TabPages"
-                class="btn btn-outline-secondary col-md-2">
+               class="btn btn-outline-secondary col-md-2">
                 Cancel
             </a>
         </div>

--- a/FMS/Pages/HsrpFacilityProperties/Edit.cshtml.cs
+++ b/FMS/Pages/HsrpFacilityProperties/Edit.cshtml.cs
@@ -1,4 +1,5 @@
 using FMS.Domain.Dto;
+using FMS.Domain.Entities;
 using FMS.Domain.Entities.Users;
 using FMS.Domain.Repositories;
 using FMS.Platform.Extensions;
@@ -77,14 +78,26 @@ namespace FMS.Pages.HsrpFacilityProperties
             return Page();
         }
 
-        public async Task<IActionResult> OnPostAsync()
+        public async Task<IActionResult> OnPostAsync(Guid id)
         {
+            if (!HsrpFacilityProperties.BrownfieldDate.HasValue && HsrpFacilityProperties.BrownfieldTerminated)
+            {
+                ModelState.AddModelError("HsrpFacilityProperties.BrownfieldTerminated", "Date of Brownfield determination must be chosen.");
+            }
+            
+            if (!HsrpFacilityProperties.VRPDate.HasValue && HsrpFacilityProperties.VRPTerminated)
+            {
+                ModelState.AddModelError("HsrpFacilityProperties.VRPTerminated", "Date of VRP determination must be chosen.");
+            }
+
             if (!ModelState.IsValid)
             {
+                HsrpFacilityProperties = await _repository.GetHsrpFacilityPropertiesEditByFacilityIdAsync(id);
+                Facility = await _facilityRepository.GetFacilityAsync(HsrpFacilityProperties.FacilityId);
                 await PopulateSelectsAsync();
                 return Page();
             }
-           
+
             await _repository.UpdateHsrpFacilityPropertiesAsync(HsrpFacilityProperties.FacilityId, HsrpFacilityProperties);
 
             TempData?.SetDisplayMessage(Context.Success, $"HSI Properties successfully Updated.");


### PR DESCRIPTION
Ensures that a date must be provided if Brownfield or VRP properties are marked as terminated. Additionally, updates the edit form layout for better alignment and ensures the page model is correctly re-populated when validation fails.

Fixes #871
Fixes #872 