### PR TITLE
Updates geocoding help text to emphasize address accuracy

### DIFF
--- a/FMS/Pages/Facilities/Add.cshtml
+++ b/FMS/Pages/Facilities/Add.cshtml
@@ -135,7 +135,7 @@
                         <span id="GeocodeAddressWarn" class="text-danger d-none">Please enter an address.</span> &nbsp;
                     </span>
                     <button id="GeocodeButton" class="btn btn-outline-primary form-control" aria-describedby="GeocodeHelpBlock">Geocode</button>
-                    <small id="GeocodeHelpBlock" class="form-text text-muted">Street address is required for geocoding. City and ZIP Code are optional.</small>
+                    <small id="GeocodeHelpBlock" class="form-text text-danger">The Address should be as accurate as possible. Incomplete addresses will produce inaccurate geocoding.</small>
                 </div>
             }
         </div>

--- a/FMS/Pages/Facilities/Edit.cshtml
+++ b/FMS/Pages/Facilities/Edit.cshtml
@@ -139,7 +139,7 @@
                     <span id="GeocodeAddressWarn" class="d-none text-danger">Please enter an address.</span> &nbsp;
                 </span>
                 <button id="GeocodeButton" class="btn btn-outline-primary form-control" aria-describedby="GeocodeHelpBlock">Geocode</button>
-                <small id="GeocodeHelpBlock" class="form-text text-muted">Street address is required for geocoding. City and ZIP Code are optional.</small>
+                <small id="GeocodeHelpBlock" class="form-text text-danger">The Address should be as accurate as possible. Incomplete addresses will produce inaccurate geocoding.</small>
             </div>
         </div>
         <div class="mb-3 row">


### PR DESCRIPTION
Updates the geocoding instructions on the Add and Edit Facility pages to warn that incomplete addresses result in inaccurate geocoding. The help text is also updated to use a danger style for better visibility.

Fixes #867