### PR TITLE
1034 Fixes paging error when FacilityTypeId is blank

### DIFF
--- a/FMS/Pages/Facilities/Index.cshtml.cs
+++ b/FMS/Pages/Facilities/Index.cshtml.cs
@@ -76,7 +76,7 @@ namespace FMS.Pages.Facilities
         public async Task<IActionResult> OnGetSearchAsync(FacilitySpec spec, [FromQuery] int p = 1)
         {
             spec.TrimAll();
-            if (!spec.FirstPass)
+            if (!spec.FirstPass && !string.IsNullOrEmpty(Request.Query["FacilityTypeId"]))
             {
                 spec.FacilityTypeId = JsonSerializer.Deserialize<List<Guid>>(Request.Query["FacilityTypeId"].ToString());
             }


### PR DESCRIPTION
Prevents a JSON deserialization error during search paging by verifying that the FacilityTypeId query parameter is not null or empty before attempting to process it.