### PR TITLE
1039 Add site summary links and search shortcuts

### DIFF
--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -338,6 +338,8 @@
     <div class="container bg-light-subtle p-3 m-1 rounded-3">
         <a class="btn btn-sm btn-primary" target="_blank" href=@Model.MapLink>Google Map</a>
         <a asp-page="/Facilities/Map" asp-route-id="@Model.FacilityDetail.Id" class="btn btn-sm btn-primary" target="_blank">Location Search</a>
+        <a asp-page="/Facilities/Index" class="btn btn-sm btn-outline-primary" target="_blank">New Search Tab</a>
+        <a asp-page="/Facilities/Map" class="btn btn-sm btn-outline-primary" target="_blank">New Map Search Tab</a>
         @if (Model.FacilityDetail.FacilityType.Name == "HSI" && Model.FacilityDetail.FacilityStatus.Name == "Active")
         {
             <a asp-page="/Reporting/SiteSummary/Report" asp-route-hsiId="@Model.FacilityDetail.FacilityNumber" target="_blank"

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using FMS.Platform
 @model FMS.Pages.Reporting.SiteSummary.IndexModel
 
 @{
@@ -174,7 +175,7 @@
                                     @Html.DisplayFor(m => item.FacilityNumber, "StringOrNone")
                                 </a>
                             </td>
-                            <td>@Html.DisplayFor(m => item.Name, "StringOrNone")</td>
+                            <td><a href="@Model.SiteSummaryURL@item.FacilityNumber" target="_blank">@Html.DisplayFor(m => item.Name, "StringOrNone")</a></td>
                             <td>@Html.DisplayFor(m => item.OrganizationalUnit.Name, "StringOrNone")</td>
                             <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")</td>
                             <td>@Html.DisplayFor(m => item.County.Name, "StringOrNone")</td>

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
@@ -1,6 +1,7 @@
 using FMS.Domain.Data;
 using FMS.Domain.Dto;
 using FMS.Domain.Repositories;
+using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -24,6 +25,8 @@ namespace FMS.Pages.Reporting.SiteSummary
 
         [BindProperty]
         public IReadOnlyList<FacilityBasicDto> SummaryList { get; set; } = [];
+
+        public string SiteSummaryURL { get; set; } = GlobalConstants.SiteSummaryReportPath;
 
         public bool ShowResults { get; private set; }
 

--- a/FMS/Platform/GlobalConstants.cs
+++ b/FMS/Platform/GlobalConstants.cs
@@ -24,5 +24,7 @@
         // Link to Google Maps API
         public const string MapCoordLink = "https://www.google.com/maps/search/?api=1&query=";
 
+
+        public const string SiteSummaryReportPath = "/Reporting/SiteSummary/Report/";
     }
 }

--- a/FMS/Properties/PublishProfiles/Publish-Production.pubxml
+++ b/FMS/Properties/PublishProfiles/Publish-Production.pubxml
@@ -15,7 +15,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <MSDeployServiceURL>fms.gaepd.org</MSDeployServiceURL>
     <DeployIisAppPath>fms</DeployIisAppPath>
     <RemoteSitePhysicalPath />
-    <SkipExtraFilesOnServer>true</SkipExtraFilesOnServer>
+    <SkipExtraFilesOnServer>false</SkipExtraFilesOnServer>
     <MSDeployPublishMethod>WMSVC</MSDeployPublishMethod>
     <EnableMSDeployBackup>true</EnableMSDeployBackup>
     <UserName>SOG\akarasch</UserName>


### PR DESCRIPTION
- Links facility names in the Site Summary Index to their respective report pages.
- Adds buttons to the Facility Details page for opening new search and map tabs.
- Updates the production publish profile to ensure server file synchronization by not skipping extra files.