### PR TITLE
1029 Add option to exclude delisted sites from HSI report

### DIFF
--- a/FMS.Domain/Dto/Reports/HSIListReportDto.cs
+++ b/FMS.Domain/Dto/Reports/HSIListReportDto.cs
@@ -25,5 +25,8 @@ namespace FMS.Domain.Dto.Reports
 
         [XLColumn(Header ="Class")]
         public string ClassName { get; set; }
+
+        [XLColumn(Header ="Facility Status")]
+        public string FacilityStatus { get; set; }
     }
 }

--- a/FMS.Domain/Repositories/IReportingRepository.cs
+++ b/FMS.Domain/Repositories/IReportingRepository.cs
@@ -50,7 +50,7 @@ namespace FMS.Domain.Repositories
 
         #region HSI ListReports
 
-        Task<IReadOnlyList<HSIListReportDto>> GetHSIListReportAsync(HSISortBy sortBy);
+        Task<IReadOnlyList<HSIListReportDto>> GetHSIListReportAsync(HSISortBy sortBy, bool excludeDelisted);
 
         #endregion
 

--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -317,20 +317,23 @@ namespace FMS.Infrastructure.Repositories
 
         #region HSI List Reports
 
-        public async Task<IReadOnlyList<HSIListReportDto>> GetHSIListReportAsync(HSISortBy sortBy)
+        public async Task<IReadOnlyList<HSIListReportDto>> GetHSIListReportAsync(HSISortBy sortBy, bool excludeDelisted)
         {
             var facilityList = await _context.Facilities.AsNoTracking()
                 .Include(e => e.FacilityType)
+                .Include(e => e.FacilityStatus)
                 .Include(e => e.LocationDetails)
                 .Include(e => e.LocationDetails.LocationClass)
                 .Include(e => e.County)
                 .Where(e => e.FacilityType.Name == "HSI")
+                .Where(e => !excludeDelisted || !string.Equals(e.FacilityStatus.Status, "DELISTED"))
                 .Select(e => new HSIListReportDto()
                 {
                     HSINumber = e.FacilityNumber,
                     Name = e.Name,
                     County = e.County.Name,
-                    ClassName = e.LocationDetails.LocationClass.Name
+                    ClassName = e.LocationDetails.LocationClass.Name,
+                    FacilityStatus = e.FacilityStatus.Status
                 })
                 .ToListAsync();
 

--- a/FMS/Pages/Reporting/HSISiteLists/Index.cshtml
+++ b/FMS/Pages/Reporting/HSISiteLists/Index.cshtml
@@ -12,6 +12,14 @@
     <form method="post">
         <div class="row">
             <div class="col-md-4">
+                <input asp-for="ExcludeDelisted" class="form-check-input" checked />
+                <label asp-for="ExcludeDelisted" class="form-check-label"></label>
+                <span asp-validation-for="ExcludeDelisted" class="text-danger"></span>
+            </div>
+        </div>
+        <hr />
+        <div class="row">
+            <div class="col-md-4">
                 <button id="ByNumber"
                         asp-page-handler="ByNumber"
                         class="btn btn-sm btn-outline-primary mb-1">

--- a/FMS/Pages/Reporting/HSISiteLists/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/HSISiteLists/Index.cshtml.cs
@@ -2,6 +2,7 @@ using FMS.Domain.Dto.Reports;
 using FMS.Domain.Repositories;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.ComponentModel.DataAnnotations;
 
 namespace FMS.Pages.Reporting.HSISiteLists
 {
@@ -10,6 +11,10 @@ namespace FMS.Pages.Reporting.HSISiteLists
         private readonly IReportingRepository _repository;
 
         public IndexModel(IReportingRepository repository) => _repository = repository;
+
+        [BindProperty]
+        [Display(Name = "Exclude Delisted Sites")]
+        public bool ExcludeDelisted { get; set; }
 
         public void OnGet()
         {
@@ -22,7 +27,7 @@ namespace FMS.Pages.Reporting.HSISiteLists
 
             // "eventsPendingList" List to go to a report
             IReadOnlyList<HSIListReportDto>
-                hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.HSINumber);
+                hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.HSINumber, ExcludeDelisted);
 
             // Export to Excel
             return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByNumber),
@@ -34,7 +39,7 @@ namespace FMS.Pages.Reporting.HSISiteLists
             var fileName = $"HSI_Sites_By_Name_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
 
             // "eventsPendingList" List to go to a report
-            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.Name);
+            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.Name, ExcludeDelisted);
 
             // Export to Excel
             return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByName),
@@ -46,7 +51,7 @@ namespace FMS.Pages.Reporting.HSISiteLists
             var fileName = $"HSI_Sites_By_County_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
 
             // "eventsPendingList" List to go to a report
-            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.County);
+            IReadOnlyList<HSIListReportDto> hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.County, ExcludeDelisted);
 
             // Export to Excel
             return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByCounty),
@@ -59,7 +64,7 @@ namespace FMS.Pages.Reporting.HSISiteLists
 
             // "eventsPendingList" List to go to a report
             IReadOnlyList<HSIListReportDto>
-                hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.ClassName);
+                hsiReportList = await _repository.GetHSIListReportAsync(HSISortBy.ClassName, ExcludeDelisted);
 
             // Export to Excel
             return File(hsiReportList.ExportExcelAsByteArray(ExportHelper.ReportType.HSIListByClass),

--- a/FMS/Pages/Reporting/_PrintToolbarPartial.cshtml
+++ b/FMS/Pages/Reporting/_PrintToolbarPartial.cshtml
@@ -19,7 +19,7 @@
                         <use href="@Url.Content("~/images/app-icons.svg")#app-icon-printer-fill"></use>
                     </svg>
                     Print</kbd>
-                button and change the Printer/Destination option to “Save as PDF.”
+                button and change the Printer/Destination option to “Save as PDF.” This also ensures that Hyperlinks within PDF documents are active. If “Microsoft print to PDF” is chosen, Hyperlinks will not be active in the document.
             </li>
             <li>
                 <strong>To hide the date/url headers and footers on the printout:</strong> Select the


### PR DESCRIPTION
Adds a checkbox to the HSI site list report page to allow filtering out delisted sites. The report now also includes the facility status column in the exported Excel spreadsheet. Updated print instructions to clarify PDF generation for active hyperlinks.