### PR TITLE
1042 Give Compliance Officers permission to edit facility location

### DIFF
--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -1,5 +1,4 @@
 ﻿using Dapper;
-using DocumentFormat.OpenXml.Office2010.Excel;
 using FMS.Domain.Dto;
 using FMS.Domain.Dto.Reports;
 using FMS.Domain.Repositories;
@@ -26,6 +25,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties.ComplianceOfficer)
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI" || e.FacilityType.Name == "VRP")
                 .Select(e => new AssignmentListReportByCODto(e))
                 .ToListAsync();
@@ -50,6 +50,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties.ComplianceOfficer)
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI" || e.FacilityType.Name == "VRP")
                 .Select(e => new AssignmentListReportByCountyDto(e))
                 .ToListAsync();
@@ -73,6 +74,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties)
                 .Include(e => e.HsrpFacilityProperties.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .Select(e => new AssignmentListReportByHSIDto(e))
                 .ToListAsync();
@@ -96,6 +98,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties)
                 .Include(e => e.HsrpFacilityProperties.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .OrderBy(e => e.Name)
                 .Select(e => new AssignmentListReportBySiteNameDto(e))
@@ -114,6 +117,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties.ComplianceOfficer)
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .Select(e => new AssignmentListReportByUnitDto(e))
                 .ToListAsync();
@@ -142,6 +146,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties.ComplianceOfficer)
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI" || e.FacilityType.Name == "VRP")
                 .Where(e => e.HsrpFacilityProperties.DateDeListed != null)
                 .Select(e => new DelistedReportByDateDto(e))
@@ -164,6 +169,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
                 .Include(e => e.Parcels)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI" || e.FacilityType.Name == "VRP")
                 .Where(e => e.HsrpFacilityProperties.DateDeListed != null &&
                             e.HsrpFacilityProperties.DateDeListed >= startDate.GetValueOrDefault() &&
@@ -188,6 +194,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.HsrpFacilityProperties.ComplianceOfficer)
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI" || e.FacilityType.Name == "VRP")
                 .Where(e => e.FacilityStatus.Status == "Active")
                 .Where(e => e.HsrpFacilityProperties.DateListed != null)
@@ -211,6 +218,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.OrganizationalUnit)
                 .Include(e => e.ComplianceOfficer)
                 .Include(e => e.Parcels)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI" || e.FacilityType.Name == "VRP")
                 .Where(e => e.FacilityStatus.Status == "Active")
                 .Where(e => e.HsrpFacilityProperties.DateListed != null &&
@@ -252,6 +260,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.Events)
                 .ThenInclude(ev => ev.EventContractor)
                 .Where(e => facilityTypes.Contains(e.FacilityType.Name))
+                .Where(e => e.Active)
                 .SelectMany(e => e.Events.Select(ev => new EventReportDto()
                     {
                         Id = ev.Id,
@@ -326,6 +335,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.LocationDetails.LocationClass)
                 .Include(e => e.County)
                 .Where(e => e.FacilityType.Name == "HSI")
+                .Where(e => e.Active)
                 .Where(e => !excludeDelisted || !string.Equals(e.FacilityStatus.Status, "DELISTED"))
                 .Select(e => new HSIListReportDto()
                 {
@@ -380,6 +390,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.StatusDetails.OverallStatus)
                 .Include(e => e.StatusDetails.AbandonedInactive)
                 .Include(e => e.StatusDetails.GAPSAssessment)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .Where(e => e.StatusDetails.OverallStatus.Name == "ABND" ||
                             e.StatusDetails.OverallStatus.Name == "INAC")
@@ -426,6 +437,7 @@ namespace FMS.Infrastructure.Repositories
                 .ThenInclude(ev => ev.ComplianceOfficer)
                 .Include(e => e.StatusDetails)
                 .Include(e => e.StatusDetails.OverallStatus)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .Where(e => e.StatusDetails.OverallStatus.Name == "ABND" ||
                             e.StatusDetails.OverallStatus.Name == "INAC")
@@ -461,6 +473,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.County)
                 .Include(e => e.ComplianceOfficer)
                 .Include(e => e.StatusDetails)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .Where(e => e.StatusDetails.OverallStatus.Name == "ABND" ||
                             e.StatusDetails.OverallStatus.Name == "INAC")
@@ -521,6 +534,7 @@ namespace FMS.Infrastructure.Repositories
                 .Include(e => e.StatusDetails.GroundwaterStatus)
                 .Include(e => e.StatusDetails.OverallStatus)
                 .Include(e => e.StatusDetails.GAPSAssessment)
+                .Where(e => e.Active)
                 .Where(e => e.FacilityType.Name == "HSI")
                 .Where(e => e.FacilityStatus.Status == "Active")
                 .Where(e => string.IsNullOrEmpty(spec.FacilityNumber) || e.FacilityNumber == spec.FacilityNumber)

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -477,7 +477,7 @@
                     <div class="tab-pane @(Model.ActiveTab == "Location" ? "active" : "")" id="Location" role="tabpanel" aria-labelledby="Location-tab">
                         <h3>
                             Location
-                            @if (User.IsInRole(UserRoles.FileEditor))
+                            @if (User.IsInRole(UserRoles.FileEditor) || User.IsInRole(UserRoles.ComplianceOfficer))
                             {
                                 <a asp-page="/Location/Edit" asp-route-id="@Model.FacilityDetail.Id" class="btn btn-sm btn-primary">Edit</a>
                             }

--- a/FMS/Pages/Location/Edit.cshtml
+++ b/FMS/Pages/Location/Edit.cshtml
@@ -1,4 +1,5 @@
 ﻿@page "{id:Guid?}"
+@using FMS.Domain.Entities.Users
 @model FMS.Pages.Location.EditModel
 
 @section Scripts
@@ -63,9 +64,17 @@
             <div class="row mb-3">
                 <div class="col mb-3">
                     <label asp-for="Location.LocationClassId" class="form-label">Class</label>
-                    <select asp-for="Location.LocationClassId" asp-items="Model.Classes" class="form-select">
-                    </select>
-                    <span asp-validation-for="Location.LocationClassId" class="text-danger"></span>
+                    @if (User.IsInRole(UserRoles.FileEditor))
+                    {
+                        <select asp-for="Location.LocationClassId" asp-items="Model.Classes" class="form-select">
+                        </select>
+                        <span asp-validation-for="Location.LocationClassId" class="text-danger"></span>
+                    }
+                    else
+                    {
+                        <select asp-for="Location.LocationClassId" asp-items="Model.Classes" class="form-select" disabled>
+                        </select>
+                    }
                 </div>
             </div>
             <input type="hidden" asp-for="Location.MapZoom" />
@@ -73,10 +82,10 @@
             <div class="row mb-3">
                 <button id="SubmitButton" type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Update</button>
                 <a asp-page="../Facilities/Details"
-                   asp-route-id="@Model.Facility.Id"
-                   asp-route-tab="Location"
-                   asp-fragment="TabPages"
-                   class="btn btn-outline-secondary col-md-2">
+                       asp-route-id="@Model.Facility.Id"
+                       asp-route-tab="Location"
+                       asp-fragment="TabPages"
+                       class="btn btn-outline-secondary col-md-2">
                     Cancel
                 </a>
             </div>

--- a/FMS/Pages/Location/Edit.cshtml.cs
+++ b/FMS/Pages/Location/Edit.cshtml.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace FMS.Pages.Location
 {
-    [Authorize(Roles = UserRoles.FileEditor)]
+    [Authorize(Policy = UserPolicies.FileEditorOrComplianceOfficer)]
     public class EditModel : PageModel
     {
         private readonly ILocationRepository _repository;

--- a/FMS/Pages/Reporting/SiteSummary/Report.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Report.cshtml.cs
@@ -37,6 +37,10 @@ namespace FMS.Pages.Reporting.SiteSummary
             if (!string.IsNullOrEmpty(hsiId))
             {
                 Report = await _repository.GetSingleFacilitySiteSummaryDtoAsync(hsiId);
+                if (Report == null) 
+                    {
+                        return NotFound();
+                    }
                 ReportList = [Report];
                 ShowHeader = false;
                 return Page();


### PR DESCRIPTION
- Updated authorization policy to allow Compliance Officers to access the facility location edit page.
- Restricted the "Location Class" field to File Editors only by disabling it for other roles.
- Filtered reporting repository queries to include only active facilities.