### PR TITLE
1046 Add additional organizational unit filters to Site Summary report

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilityBasicDto.cs
+++ b/FMS.Domain/Dto/Facility/FacilityBasicDto.cs
@@ -16,6 +16,7 @@ namespace FMS.Domain.Dto
             Latitude = facility.Latitude;
             Longitude = facility.Longitude;
             LocationClass = facility.LocationDetails?.LocationClass;
+            AddlOrgUnit = facility.HsrpFacilityProperties?.OrganizationalUnit;
         }
 
         public Guid Id { get; }
@@ -46,5 +47,8 @@ namespace FMS.Domain.Dto
 
         [Display(Name = "Location Class")]
         public LocationClass LocationClass { get; set; }
+
+        [Display(Name = "Add'l Org Unit")]
+        public OrganizationalUnit AddlOrgUnit { get; set; }
     }
 }

--- a/FMS.Domain/Dto/Reports/SiteSummaryQuerySpec.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryQuerySpec.cs
@@ -4,6 +4,9 @@
     {
         public SiteSummaryQuerySpec() { }
 
+        [Display(Name = "Include")]
+        public SiteSummaryAddlOrgUnitInclusion Include { get; set; } = SiteSummaryAddlOrgUnitInclusion.All;
+
         [Display(Name = "Sort By")]
         public SiteSummarySortBy SortBy { get; set; } = SiteSummarySortBy.FacilityNumber;   
 
@@ -57,7 +60,8 @@
             { nameof(AllClassIVs), AllClassIVs.ToString() },
             { nameof(AllOrgUnits), AllOrgUnits.ToString() },
             { nameof(ShowHeader), ShowHeader.ToString() },
-            { nameof(SortBy), SortBy.ToString() }
+            { nameof(SortBy), SortBy.ToString() },
+            { nameof(Include), Include.ToString() }
         };
 
         public void TrimAll()
@@ -70,6 +74,13 @@
             FacilityNumber,
             County,
             LocationClass
+        }
+
+        public enum SiteSummaryAddlOrgUnitInclusion
+        {
+            All,
+            Include,
+            Exclude
         }
     }
 }

--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -241,7 +241,7 @@ namespace FMS.Infrastructure.Repositories
         public async Task<IList<EventReportDto>> GetEventsReportsAsync(
             List<string> facilityTypes = null,
             EventReportSpecDto eventReportSpec = null)
-        {   
+        {
             List<EventReportDto> reportDtoList = await _context.Facilities
                 .AsNoTracking()
                 .Include(e => e.FacilityType)
@@ -260,31 +260,31 @@ namespace FMS.Infrastructure.Repositories
                 .ThenInclude(ev => ev.EventContractor)
                 .Where(e => facilityTypes.Contains(e.FacilityType.Name))
                 .Where(e => eventReportSpec.OrganizationalUnitId == null || eventReportSpec.OrganizationalUnitId.Contains(e.OrganizationalUnit.Id))
-                .Where(ev => eventReportSpec.ComplianceOfficerId == null || eventReportSpec.ComplianceOfficerId.Contains(ev.ComplianceOfficer.Id))
                 .Where(e => e.Active)
                 .SelectMany(e => e.Events.Select(ev => new EventReportDto()
-                    {
-                        Id = ev.Id,
-                        FacilityId = e.Id,
-                        ParentId = ev.ParentId,
-                        FacilityNumber = e.FacilityNumber,
-                        FacilityName = e.Name,
-                        FacilityType = e.FacilityType,
-                        EventType = ev.EventType,
-                        ActionTaken = ev.ActionTaken,
-                        StartDate = ev.StartDate,
-                        DueDate = ev.DueDate,
-                        CompletionDate = ev.CompletionDate,
-                        DoneBy = ev.ComplianceOfficer,
-                        OrganizationalUnit = e.OrganizationalUnit,
-                        ComplianceOfficer = e.ComplianceOfficer,
-                        EventAmount = ev.EventAmount,
-                        EventContractor = ev.EventContractor,
-                        Comment = ev.Comment,
-                        OverallStatus = e.StatusDetails.OverallStatus,
-                        ListDate = e.HsrpFacilityProperties.DateListed
-                    })
-                    .Where(ev => eventReportSpec.EventTypeId == null || eventReportSpec.EventTypeId.Contains(ev.EventType.Id)))
+                {
+                    Id = ev.Id,
+                    FacilityId = e.Id,
+                    ParentId = ev.ParentId,
+                    FacilityNumber = e.FacilityNumber,
+                    FacilityName = e.Name,
+                    FacilityType = e.FacilityType,
+                    EventType = ev.EventType,
+                    ActionTaken = ev.ActionTaken,
+                    StartDate = ev.StartDate,
+                    DueDate = ev.DueDate,
+                    CompletionDate = ev.CompletionDate,
+                    DoneBy = ev.ComplianceOfficer,
+                    OrganizationalUnit = e.OrganizationalUnit,
+                    ComplianceOfficer = e.ComplianceOfficer,
+                    EventAmount = ev.EventAmount,
+                    EventContractor = ev.EventContractor,
+                    Comment = ev.Comment,
+                    OverallStatus = e.StatusDetails.OverallStatus,
+                    ListDate = e.HsrpFacilityProperties.DateListed
+                })
+                    .Where(ev => eventReportSpec.EventTypeId == null || eventReportSpec.EventTypeId.Contains(ev.EventType.Id))
+                    .Where(ev => eventReportSpec.ComplianceOfficerId == null || eventReportSpec.ComplianceOfficerId.Contains(ev.DoneBy.Id)))
                 .ToListAsync();
 
             return reportDtoList;
@@ -575,7 +575,25 @@ namespace FMS.Infrastructure.Repositories
                     break;
             }
 
-            return siteSummarySorted;
+            List<SiteSummaryReportDto> AdditionalFiltered;
+            switch (spec.Include)
+            {
+                case SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.Include:
+                    AdditionalFiltered = siteSummarySorted
+                        .Where(e => e.HsrpFacilityPropertyDetails.OrganizationalUnit != null)
+                        .ToList();
+                    break;
+                case SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.Exclude:
+                    AdditionalFiltered = siteSummarySorted
+                        .Where(e => e.HsrpFacilityPropertyDetails.OrganizationalUnit == null)
+                        .ToList();
+                    break;
+                default:
+                    AdditionalFiltered = siteSummarySorted;
+                    break;
+            }
+
+            return AdditionalFiltered;
         }
 
         public async Task<IReadOnlyList<FacilityBasicDto>> GetHsiFacilitiesAsync(SiteSummaryQuerySpec spec)
@@ -627,9 +645,27 @@ namespace FMS.Infrastructure.Repositories
                     break;
             }
 
-            return siteSummarySorted;
+            List<FacilityBasicDto> AdditionalFiltered;
+            switch (spec.Include)
+            {
+                case SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.Include:
+                    AdditionalFiltered = siteSummarySorted
+                        .Where(e => e.AddlOrgUnit != null)
+                        .ToList();
+                    break;
+                case SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.Exclude:
+                    AdditionalFiltered = siteSummarySorted
+                        .Where(e => e.AddlOrgUnit == null)
+                        .ToList();
+                    break;
+                default:
+                    AdditionalFiltered = siteSummarySorted;
+                    break;
+            }
+
+            return AdditionalFiltered;
         }
-            
+
         public async Task<SiteSummaryReportDto> GetSingleFacilitySiteSummaryDtoAsync(string hsiId)
         {
             var facility = await _context.Facilities.AsNoTracking()

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml
@@ -55,30 +55,60 @@
             </div>
         </div>
         <hr />
-        <div class="row">
-            <div class="col-md-3">
-                <div class="form-check">
-                    <input asp-for="Spec.IsLandFill" />
-                    <label asp-for="Spec.IsLandFill" class="form-check-label" disabled="true"></label>
+        <div class="row text-center">
+            <div class="col-md-6">
+                <div class="row">
+                    <p>
+                        Choose Sorting Order
+                    </p>
+                </div>
+                <div class="row">
+                    <div class="col-md-4">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.FacilityNumber)
+                            Facility Number
+                        </label>
+                    </div>
+                    <div class="col-md-4">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.County)
+                            County
+                        </label>
+                    </div>
+                    <div class="col-md-4">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.LocationClass)
+                            Class
+                        </label>
+                    </div>
                 </div>
             </div>
-            <div class="col-md-3">
-                <label>
-                    @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.FacilityNumber)
-                    Sort By Facility Number
-                </label>
-            </div>
-            <div class="col-md-3">
-                <label>
-                    @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.County)
-                    Sort By County
-                </label>
-            </div>
-            <div class="col-md-3">
-                <label>
-                    @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.LocationClass)
-                    Sort By Class
-                </label>
+            <div class="col-md-6">
+                <div class="row">
+                    <p>
+                        Choose Additional Org. Unit Inclusions/Exclusions
+                    </p>
+                </div>
+                <div class="row">
+                    <div class="col-md-4">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.Include, SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.All)
+                            Include All
+                        </label>
+                    </div>
+                    <div class="col-md-4">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.Include, SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.Exclude)
+                            Exclude w/ Add'l
+                        </label>
+                    </div>
+                    <div class="col-md-4">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.Include, SiteSummaryQuerySpec.SiteSummaryAddlOrgUnitInclusion.Include)
+                            Only w/ Add'l
+                        </label>
+                    </div>
+                </div>
             </div>
         </div>
         <hr />
@@ -87,6 +117,12 @@
                 <div class="form-check">
                     <input asp-for="Spec.ShowHeader" />
                     <label asp-for="Spec.ShowHeader" class="form-check-label"></label>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <div class="form-check">
+                    <input asp-for="Spec.IsLandFill" />
+                    <label asp-for="Spec.IsLandFill" class="form-check-label" disabled="true"></label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Adds radio buttons to the Site Summary report to filter facilities by the presence or absence of an additional organizational unit.
- Updates the reporting repository to apply these inclusion/exclusion filters to both Site Summary and HSI facility reports.
- Corrects a filtering logic error in the Events Report where compliance officer IDs were being checked against the wrong property.