### PR TITLE
1059 Add Site Summary PDF list export for ESRI

### DIFF
--- a/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
@@ -1,0 +1,126 @@
+﻿using ClosedXML.Attributes;
+using FMS.Domain.Entities;
+
+namespace FMS.Domain.Dto.Reports
+{
+    public class SiteSummaryPdfListDto
+    {
+        private const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        private const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        private const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        private const string pdfSuffix = ".pdf";
+
+        public SiteSummaryPdfListDto(Facility facility)
+        {
+            FacilityNumber = facility.FacilityNumber;
+            FacilityName = facility.Name;
+            Latitude = facility.Latitude;
+            Longitude = facility.Longitude;
+            Address = facility.Address;
+            City = facility.City;
+            County = facility.County.Name;
+            ListDate = facility.HsrpFacilityProperties.DateListed;
+            Class = facility.LocationDetails.LocationClass.Name;
+            InvestigationCleanupFunding = facility.StatusDetails.FundingSource.Name switch
+            {
+                "A" => "A",
+                "LE" => "L",
+                "LI" => "RP",
+                "P" => "RP",
+                "SE" => "L",
+                "SI" => "RP",
+                _ => string.Empty
+            };
+            Icon = facility.StatusDetails.FundingSource.Name switch
+            {
+                "A" => "small_yellow",
+                "LE" => "small_green",
+                "LI" => "small_green",
+                "P" => "small_red",
+                "SE" => "small_red",
+                "SI" => "small_red",
+                _ => string.Empty
+            };
+            //SiteSummaryUrl = SiteSummaryReportPathPdf + FacilityNumber + pdfSuffix;
+        }
+
+        [Display(Name = "HSI ID")]
+        [XLColumn(Header = "HSI ID")]
+        public string FacilityNumber { get; set; }
+
+        [Display(Name = "Facility Name")]
+        [XLColumn(Header = "Facility Name")]
+        public string FacilityName { get; set; }
+
+        [Display(Name = "Latitude")]
+        [XLColumn(Header = "Latitude")]
+        public decimal Latitude { get; set; }
+
+        [Display(Name = "Longitude")]
+        [XLColumn(Header = "Longitude")]
+        public decimal Longitude { get; set; }
+
+        [Display(Name = "Address")]
+        [XLColumn(Header = "Address")]
+        public string Address { get; set; }
+        
+        [Display(Name = "City")]
+        [XLColumn(Header = "City")]
+        public string City { get; set; }
+        
+        [Display(Name = "County")]
+        [XLColumn(Header = "County")]
+        public string County { get; set; }
+
+        [Display(Name = "List Date")]
+        [XLColumn(Header = "List Date")]
+        public DateOnly? ListDate { get; set; }
+
+        [Display(Name = "Class")]
+        [XLColumn(Header = "Class")]
+        public string Class { get; set; }
+
+        [Display(Name = "Site Summary")]
+        [XLColumn(Header = "Site Summary")]
+        public string SiteSummaryUrl
+        {
+            get
+            {
+                // Determine the environment and return the appropriate URL
+                string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
+                return environment switch
+                {
+                    "Development" => siteSummaryReportPathPdfDev + FacilityNumber + pdfSuffix,
+                    "UAT" => siteSummaryReportPathPdfUat + FacilityNumber + pdfSuffix,
+                    _ => siteSummaryReportPathPdfProd + FacilityNumber + pdfSuffix,
+                };
+            }
+        }
+
+        [Display(Name = "Investigation/Cleanup Funding")]
+        [XLColumn(Header = "Investigation/Cleanup Funding")]
+        public string InvestigationCleanupFunding { get; set; }
+
+        [Display(Name = "Icon")]
+        [XLColumn(Header = "Icon")]
+        public string Icon { get; set; }
+
+        //public string SiteSummaryReportPathPdf
+        //{
+        //    get
+        //    {
+        //        // Determine the environment and return the appropriate URL
+        //        string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
+        //        return environment switch
+        //        {
+        //            "Development" => siteSummaryReportPathPdfDev,
+        //            "UAT" => siteSummaryReportPathPdfUat,
+        //            _ => siteSummaryReportPathPdfProd,
+        //        };
+        //    }
+        //}
+    }
+}

--- a/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
@@ -44,7 +44,6 @@ namespace FMS.Domain.Dto.Reports
                 "SI" => "small_red",
                 _ => string.Empty
             };
-            //SiteSummaryUrl = SiteSummaryReportPathPdf + FacilityNumber + pdfSuffix;
         }
 
         [Display(Name = "HSI ID")]
@@ -107,20 +106,5 @@ namespace FMS.Domain.Dto.Reports
         [Display(Name = "Icon")]
         [XLColumn(Header = "Icon")]
         public string Icon { get; set; }
-
-        //public string SiteSummaryReportPathPdf
-        //{
-        //    get
-        //    {
-        //        // Determine the environment and return the appropriate URL
-        //        string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
-        //        return environment switch
-        //        {
-        //            "Development" => siteSummaryReportPathPdfDev,
-        //            "UAT" => siteSummaryReportPathPdfUat,
-        //            _ => siteSummaryReportPathPdfProd,
-        //        };
-        //    }
-        //}
     }
 }

--- a/FMS.Domain/Repositories/IReportingRepository.cs
+++ b/FMS.Domain/Repositories/IReportingRepository.cs
@@ -75,6 +75,8 @@ namespace FMS.Domain.Repositories
 
         Task<IReadOnlyList<SiteSummaryListDto>> GetSiteSummaryListAsync(SiteSummaryQuerySpec spec);
 
+        Task<IReadOnlyList<SiteSummaryPdfListDto>> GetSiteSummaryPdfListAsync(SiteSummaryQuerySpec spec);
+
         #endregion
     }
 }

--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -726,6 +726,32 @@ namespace FMS.Infrastructure.Repositories
                 .Select(e => new SiteSummaryListDto(e))
                 .ToListAsync();
 
+        public async Task<IReadOnlyList<SiteSummaryPdfListDto>> GetSiteSummaryPdfListAsync(SiteSummaryQuerySpec spec) =>
+            await _context.Facilities
+                .Include(e => e.County)
+                .Include(e => e.HsrpFacilityProperties)
+                .Include(e => e.LocationDetails)
+                .ThenInclude(e => e.LocationClass)
+                .Include(e => e.StatusDetails)
+                .ThenInclude(e => e.FundingSource)
+                .Where(e => e.Active)
+                .Where(e => e.FacilityStatus.Status == "Active")
+                .Where(e => e.FacilityType.Name == "HSI")
+                .Where(e => string.IsNullOrEmpty(spec.FacilityNumber) || e.FacilityNumber == spec.FacilityNumber)
+                .Where(e => !spec.CountyId.HasValue || e.County.Id == spec.CountyId.Value)
+                .Where(e => !spec.ComplianceOfficerId.HasValue ||
+                            e.ComplianceOfficer.Id.Equals(spec.ComplianceOfficerId))
+                .Where(e => !spec.LocationClassId.HasValue ||
+                            e.LocationDetails.LocationClass.Id.Equals(spec.LocationClassId))
+                .Where(e => !spec.OrganizationalUnitId.HasValue ||
+                            e.OrganizationalUnit.Id.Equals(spec.OrganizationalUnitId))
+                .Where(e => !spec.AdditionalOrganizationalUnitId.HasValue ||
+                            e.HsrpFacilityProperties.OrganizationalUnit.Id.Equals(spec.AdditionalOrganizationalUnitId))
+                .Where(e => !spec.IsLandFill || e.StatusDetails.LandFill)
+                .OrderBy(e => e.FacilityNumber)
+                .Select(e => new SiteSummaryPdfListDto(e))
+                .ToListAsync();
+
 
         #endregion
 

--- a/FMS/Helpers/ExportHelper.cs
+++ b/FMS/Helpers/ExportHelper.cs
@@ -34,7 +34,8 @@ namespace FMS
             HSIListByClass,
             AbndInacStatusTracker,
             AbndCostEstimateReport,
-            SiteSummaryList
+            SiteSummaryList,
+            SiteSummaryPdfList
         }
 
         /// <summary>
@@ -570,7 +571,34 @@ namespace FMS
                 table.ShowHeaderRow = true;
                 ws.Columns().AdjustToContents(1, 10000);
 
+                ws.Column(8).Style.NumberFormat.NumberFormatId =
+                    (int)XLPredefinedFormat.DateTime.DayMonthAbbrYear2WithDashes;
+
                 var urlColumn = table.DataRange.Column(3);
+
+                foreach (var cell in urlColumn.Cells())
+                {
+                    string urlValue = cell.Value.ToString();
+                    if (!string.IsNullOrWhiteSpace(urlValue))
+                    {
+                        // Apply the hyperlink
+                        cell.SetHyperlink(new XLHyperlink(urlValue));
+
+                        // Optional: Style as a link (blue and underlined)
+                        cell.Style.Font.FontColor = XLColor.Blue;
+                        cell.Style.Font.Underline = XLFontUnderlineValues.Single;
+                    }
+                }
+            }
+
+            if (reportType == ReportType.SiteSummaryPdfList)
+            {
+                ws = wb.AddWorksheet("Site Summary ESRI Pdf List");
+                table = ws.Cell(1, 1).InsertTable(list);
+                table.ShowHeaderRow = true;
+                ws.Columns().AdjustToContents(1, 10000);
+
+                var urlColumn = table.DataRange.Column(10);
 
                 foreach (var cell in urlColumn.Cells())
                 {

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml
@@ -1,6 +1,6 @@
 ﻿@page
 @using FMS.Domain.Dto
-@using FMS.Platform
+@using FMS.Domain.Entities.Users
 @model FMS.Pages.Reporting.SiteSummary.IndexModel
 
 @{
@@ -198,7 +198,17 @@
                             Export/Print List
                         </a>
                     </div>
-                </div>
+                    @if (User.IsInRole(UserRoles.SiteMaintenance))
+                        {
+                            <div class="col-auto d-print-none ms-2">
+                                <button id="ExportEsriButton"
+                                asp-page-handler="ExportEsriButton"
+                                class="btn btn-sm btn-primary mb-1">
+                                    Export List to Excel for ESRI
+                                </button>
+                            </div>
+                        }
+                    </div>
             </form>
         }
     </div>

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
@@ -5,7 +5,6 @@ using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
-using FMS.Domain.Entities.Users;
 using FMS.Domain.Dto.Reports;
 
 namespace FMS.Pages.Reporting.SiteSummary

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
@@ -5,6 +5,8 @@ using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using FMS.Domain.Entities.Users;
+using FMS.Domain.Dto.Reports;
 
 namespace FMS.Pages.Reporting.SiteSummary
 {
@@ -76,6 +78,16 @@ namespace FMS.Pages.Reporting.SiteSummary
             IReadOnlyList<SiteSummaryListDto> facilityReportList = await _repository.GetSiteSummaryListAsync(Spec);
 
             return File(facilityReportList.ExportExcelAsByteArray(ExportHelper.ReportType.SiteSummaryList), "application/vnd.ms-excel", fileName);
+        }
+
+        public async Task<IActionResult> OnPostExportEsriButtonAsync()
+        {
+            var fileName = $"FMS_Site_Summary_ESRI_Pdf_List_export_{DateTime.Now:yyyy-MM-dd-HH-mm-ss.FFF}.xlsx";
+
+            // "FacilityReportList" Detailed Facility List to go to a report
+            IReadOnlyList<SiteSummaryPdfListDto> facilityReportList = await _repository.GetSiteSummaryPdfListAsync(Spec);
+
+            return File(facilityReportList.ExportExcelAsByteArray(ExportHelper.ReportType.SiteSummaryPdfList), "application/vnd.ms-excel", fileName);
         }
     }
 }


### PR DESCRIPTION
Introduces a new Excel export for Site Summary data, including environment-specific hyperlinks to individual site summary PDF reports. This functionality is accessible to users with the Site Maintenance role and is intended for use with ESRI systems.