### PR TITLE
Add sorting and additional columns to Site Summary list; dynamically generate PDF links

### DIFF
--- a/FMS.Domain/DomainConstants.cs
+++ b/FMS.Domain/DomainConstants.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FMS.Domain
+{
+    public class DomainConstants
+    {
+        public const string SiteSummaryReportPath = "/Reporting/SiteSummary/Report/";
+
+        public const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        public const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        public const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        public const string pdfSuffix = ".pdf";
+    }
+}

--- a/FMS.Domain/Dto/Reports/SiteSummaryListDto.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryListDto.cs
@@ -5,13 +5,20 @@ namespace FMS.Domain.Dto
 {
     public class SiteSummaryListDto
     {
-        private const string siteSummaryReportPath = "https://fms.gaepd.org/Reporting/SiteSummary/Report/";
+        private const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        private const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        private const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+
+        private const string pdfSuffix = ".pdf";
 
         public SiteSummaryListDto(Facility facility) 
         {
             FacilityNumber = facility.FacilityNumber;
             FacilityName = facility.Name;
-            SiteSummaryUrl = siteSummaryReportPath + facility.FacilityNumber;
+            County = facility.County.Name;
+            Class = facility.LocationDetails.LocationClass.Name;
         }
 
         [Display(Name = "HSI ID")]
@@ -22,9 +29,30 @@ namespace FMS.Domain.Dto
         [XLColumn(Header = "Facility Name")]
         public string FacilityName { get; set; }
 
+        [Display(Name = "County")]
+        [XLColumn(Header = "County")]
+        public string County { get; set; }
+
+        [Display(Name = "Class")]
+        [XLColumn(Header = "Class")]
+        public string Class { get; set; }
+
         [Display(Name = "Site Summary")]
         [XLColumn(Header = "Site Summary")]
-        public string SiteSummaryUrl { get; set; }
+        public string SiteSummaryUrl
+        {
+            get
+            {
+                // Determine the environment and return the appropriate URL
+                string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
+                return environment switch
+                {
+                    "Development" => siteSummaryReportPathPdfDev + FacilityNumber + pdfSuffix,
+                    "UAT" => siteSummaryReportPathPdfUat + FacilityNumber + pdfSuffix,
+                    _ => siteSummaryReportPathPdfProd + FacilityNumber + pdfSuffix,
+                };
+            }
+        }
 
     }
 }

--- a/FMS.Domain/Dto/Reports/SiteSummaryListDto.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryListDto.cs
@@ -5,15 +5,7 @@ namespace FMS.Domain.Dto
 {
     public class SiteSummaryListDto
     {
-        private const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
-
-        private const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/26-";
-
-        private const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
-
-        private const string pdfSuffix = ".pdf";
-
-        public SiteSummaryListDto(Facility facility) 
+        public SiteSummaryListDto(Facility facility)
         {
             FacilityNumber = facility.FacilityNumber;
             FacilityName = facility.Name;
@@ -47,9 +39,9 @@ namespace FMS.Domain.Dto
                 string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
                 return environment switch
                 {
-                    "Development" => siteSummaryReportPathPdfDev + FacilityNumber + pdfSuffix,
-                    "UAT" => siteSummaryReportPathPdfUat + FacilityNumber + pdfSuffix,
-                    _ => siteSummaryReportPathPdfProd + FacilityNumber + pdfSuffix,
+                    "Development" => DomainConstants.siteSummaryReportPathPdfDev + FacilityNumber + DomainConstants.pdfSuffix,
+                    "UAT" => DomainConstants.siteSummaryReportPathPdfUat + FacilityNumber + DomainConstants.pdfSuffix,
+                    _ => DomainConstants.siteSummaryReportPathPdfProd + FacilityNumber + DomainConstants.pdfSuffix,
                 };
             }
         }

--- a/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
@@ -1,18 +1,11 @@
 ﻿using ClosedXML.Attributes;
 using FMS.Domain.Entities;
+using FMS;
 
 namespace FMS.Domain.Dto.Reports
 {
     public class SiteSummaryPdfListDto
     {
-        private const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
-
-        private const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/26-";
-
-        private const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
-
-        private const string pdfSuffix = ".pdf";
-
         public SiteSummaryPdfListDto(Facility facility)
         {
             FacilityNumber = facility.FacilityNumber;
@@ -92,9 +85,9 @@ namespace FMS.Domain.Dto.Reports
                 string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
                 return environment switch
                 {
-                    "Development" => siteSummaryReportPathPdfDev + FacilityNumber + pdfSuffix,
-                    "UAT" => siteSummaryReportPathPdfUat + FacilityNumber + pdfSuffix,
-                    _ => siteSummaryReportPathPdfProd + FacilityNumber + pdfSuffix,
+                    "Development" => DomainConstants.siteSummaryReportPathPdfDev + FacilityNumber + DomainConstants.pdfSuffix,
+                    "UAT" => DomainConstants.siteSummaryReportPathPdfUat + FacilityNumber + DomainConstants.pdfSuffix,
+                    _ => DomainConstants.siteSummaryReportPathPdfProd + FacilityNumber + DomainConstants.pdfSuffix,
                 };
             }
         }

--- a/FMS.Domain/Dto/Reports/SiteSummaryQuerySpec.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryQuerySpec.cs
@@ -83,5 +83,27 @@
             Include,
             Exclude
         }
-    }
+
+        public string GetSiteSummarySortText(SiteSummarySortBy sortBy)
+        {
+            var title = "";
+            switch (sortBy)
+            {
+                case SiteSummarySortBy.Facility_Number:
+                    title += " Facility Number";
+                    break;
+                case SiteSummarySortBy.Facility_Name:
+                    title += " Facility Name";
+                    break;
+                case SiteSummarySortBy.County:
+                    title += " County";
+                    break;
+                case SiteSummarySortBy.Class:
+                    title += " Class";
+                    break;
+            }
+            
+            return title;
+        }
+}
 }

--- a/FMS.Domain/Dto/Reports/SiteSummaryQuerySpec.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryQuerySpec.cs
@@ -8,7 +8,7 @@
         public SiteSummaryAddlOrgUnitInclusion Include { get; set; } = SiteSummaryAddlOrgUnitInclusion.All;
 
         [Display(Name = "Sort By")]
-        public SiteSummarySortBy SortBy { get; set; } = SiteSummarySortBy.FacilityNumber;   
+        public SiteSummarySortBy SortBy { get; set; } = SiteSummarySortBy.Facility_Number;   
 
         [Display(Name = "Facility Number")]
         public string FacilityNumber { get; set; }
@@ -71,9 +71,10 @@
 
         public enum SiteSummarySortBy
         {
-            FacilityNumber,
+            Facility_Number,
+            Facility_Name,
             County,
-            LocationClass
+            Class
         }
 
         public enum SiteSummaryAddlOrgUnitInclusion

--- a/FMS.Infrastructure/Repositories/ReportingRepository.cs
+++ b/FMS.Infrastructure/Repositories/ReportingRepository.cs
@@ -562,7 +562,7 @@ namespace FMS.Infrastructure.Repositories
                         .ThenBy(e => e.FacilityNumber)
                         .ToList();
                     break;
-                case SiteSummaryQuerySpec.SiteSummarySortBy.LocationClass:
+                case SiteSummaryQuerySpec.SiteSummarySortBy.Class:
                     siteSummarySorted = facilityList
                         .OrderBy(e => e.LocationDetails.LocationClass.Name)
                         .ThenBy(e => e.FacilityNumber)
@@ -632,12 +632,17 @@ namespace FMS.Infrastructure.Repositories
                         .ThenBy(e => e.FacilityNumber)
                         .ToList();
                     break;
-                case SiteSummaryQuerySpec.SiteSummarySortBy.LocationClass:
+                case SiteSummaryQuerySpec.SiteSummarySortBy.Class:
                     siteSummarySorted = siteSummaryUnsorted
                         .OrderBy(e => e.LocationClass.Name)
                         .ThenBy(e => e.FacilityNumber)
                         .ToList();
                     break;
+                    case SiteSummaryQuerySpec.SiteSummarySortBy.Facility_Name:
+                        siteSummarySorted = siteSummaryUnsorted
+                        .OrderBy(e => e.Name)
+                        .ToList();
+                        break;
                 default:
                     siteSummarySorted = siteSummaryUnsorted
                         .OrderBy(e => e.FacilityNumber)
@@ -706,8 +711,13 @@ namespace FMS.Infrastructure.Repositories
             return facility;
         }
 
-        public async Task<IReadOnlyList<SiteSummaryListDto>> GetSiteSummaryListAsync(SiteSummaryQuerySpec spec) =>
-            await _context.Facilities
+        public async Task<IReadOnlyList<SiteSummaryListDto>> GetSiteSummaryListAsync(SiteSummaryQuerySpec spec)
+        {
+            var facilities = await _context.Facilities
+                .Include(e => e.County)
+                .Include(e => e.HsrpFacilityProperties)
+                .Include(e => e.LocationDetails)
+                .ThenInclude(e => e.LocationClass)
                 .Where(e => e.Active)
                 .Where(e => e.FacilityStatus.Status == "Active")
                 .Where(e => e.FacilityType.Name == "HSI")
@@ -722,9 +732,38 @@ namespace FMS.Infrastructure.Repositories
                 .Where(e => !spec.AdditionalOrganizationalUnitId.HasValue ||
                             e.HsrpFacilityProperties.OrganizationalUnit.Id.Equals(spec.AdditionalOrganizationalUnitId))
                 .Where(e => !spec.IsLandFill || e.StatusDetails.LandFill)
-                .OrderBy(e => e.FacilityNumber)
                 .Select(e => new SiteSummaryListDto(e))
                 .ToListAsync();
+
+            List<SiteSummaryListDto> siteSummarySorted;
+            switch (spec.SortBy)
+            {
+                case SiteSummaryQuerySpec.SiteSummarySortBy.County:
+                    siteSummarySorted = facilities
+                        .OrderBy(e => e.County.ToString())
+                        .ThenBy(e => e.FacilityName)
+                        .ToList();
+                    break;
+                case SiteSummaryQuerySpec.SiteSummarySortBy.Class:
+                    siteSummarySorted = facilities
+                        .OrderBy(e => e.Class.ToString())
+                        .ThenBy(e => e.FacilityName)
+                        .ToList();
+                    break;
+                case SiteSummaryQuerySpec.SiteSummarySortBy.Facility_Name:
+                    siteSummarySorted = facilities
+                    .OrderBy(e => e.FacilityName)
+                    .ToList();
+                    break;
+                default:
+                    siteSummarySorted = facilities
+                        .OrderBy(e => e.FacilityNumber)
+                        .ToList();
+                    break;
+            }
+
+            return siteSummarySorted;
+        }
 
         public async Task<IReadOnlyList<SiteSummaryPdfListDto>> GetSiteSummaryPdfListAsync(SiteSummaryQuerySpec spec) =>
             await _context.Facilities

--- a/FMS/Helpers/ExportHelper.cs
+++ b/FMS/Helpers/ExportHelper.cs
@@ -571,7 +571,7 @@ namespace FMS
                 table.ShowHeaderRow = true;
                 ws.Columns().AdjustToContents(1, 10000);
 
-                var urlColumn = table.DataRange.Column(3);
+                var urlColumn = table.DataRange.Column(5);
 
                 foreach (var cell in urlColumn.Cells())
                 {

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml
@@ -63,21 +63,27 @@
                     </p>
                 </div>
                 <div class="row">
-                    <div class="col-md-4">
+                    <div class="col-md-3">
                         <label>
-                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.FacilityNumber)
+                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.Facility_Number)
                             Facility Number
                         </label>
                     </div>
-                    <div class="col-md-4">
+                    <div class="col-md-3">
+                        <label>
+                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.Facility_Name)
+                            Facility Name
+                        </label>
+                    </div>
+                    <div class="col-md-3">
                         <label>
                             @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.County)
                             County
                         </label>
                     </div>
-                    <div class="col-md-4">
+                    <div class="col-md-3">
                         <label>
-                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.LocationClass)
+                            @Html.RadioButtonFor(m => m.Spec.SortBy, SiteSummaryQuerySpec.SiteSummarySortBy.Class)
                             Class
                         </label>
                     </div>
@@ -178,6 +184,7 @@
                 <input type="hidden" asp-for="Spec.IsLandFill" />
                 <input type="hidden" asp-for="Spec.LocationClassId" />
                 <input type="hidden" asp-for="Spec.OrganizationalUnitId" />
+                <input type="hidden" asp-for="Spec.SortBy" />
                 <div class="row">
                     <div class="col-auto">
                         <h3>Site Summary URL List</h3>
@@ -228,6 +235,7 @@
                         <th scope="col">Organizational Unit</th>
                         <th scope="col">Compliance Officer</th>
                         <th scope="col">County</th>
+                        <th scope="col">Class</th>
                         <th scope="col">Latitude/Longitude</th>
                     </tr>
                 </thead>
@@ -244,6 +252,7 @@
                             <td>@Html.DisplayFor(m => item.OrganizationalUnit.Name, "StringOrNone")</td>
                             <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")</td>
                             <td>@Html.DisplayFor(m => item.County.Name, "StringOrNone")</td>
+                            <td>@Html.DisplayFor(m => item.LocationClass.Name, "StringOrNone")</td>
                             <td>
                                 @Html.DisplayFor(m => item.Latitude, "DecimalOrNone")/@Html.DisplayFor(m => item.Longitude, "DecimalOrNone")
                             </td>

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace FMS.Pages.Reporting.SiteSummary
         [BindProperty]
         public IReadOnlyList<FacilityBasicDto> SummaryList { get; set; } = [];
 
-        public string SiteSummaryURL { get; set; }
+        public string SiteSummaryURL { get; set; } = GlobalConstants.SiteSummaryReportPath;
 
         public bool ShowResults { get; private set; }
 

--- a/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
+++ b/FMS/Pages/Reporting/SiteSummary/Index.cshtml.cs
@@ -27,7 +27,7 @@ namespace FMS.Pages.Reporting.SiteSummary
         [BindProperty]
         public IReadOnlyList<FacilityBasicDto> SummaryList { get; set; } = [];
 
-        public string SiteSummaryURL { get; set; } = GlobalConstants.SiteSummaryReportPath;
+        public string SiteSummaryURL { get; set; }
 
         public bool ShowResults { get; private set; }
 

--- a/FMS/Pages/Reporting/SiteSummary/SiteSummaryList.cshtml
+++ b/FMS/Pages/Reporting/SiteSummary/SiteSummaryList.cshtml
@@ -5,21 +5,25 @@
 }
 
 @{
-    ViewData["Title"] = $"Site Summary List";
+    ViewData["Title"] = $"Site Summary List by {Model.Spec.SortBy.ToString()}";
 }
 <div class="page-wrapper">
-    <h3>@ViewData["Title"]</h3>
+    <h3 class="centered-content">@ViewData["Title"]</h3>
     <hr />
     <div class="summarylisthead">
-        <div><strong>HSI Number</strong></div>
-        <div><strong>Site Name</strong></div>
-        <div><strong>Site Summary Report</strong></div>
+        <div><strong>HSI #</strong></div>
+        <div class="centered-content"><strong>Site Name</strong></div>
+        <div><strong>County</strong></div>
+        <div class="centered-content"><strong>Class</strong></div>
+        <div class="centered-content"><strong>Site Summary Report</strong></div>
     </div>
     <div class="summarylist">
         @foreach (var report in Model.ReportList)
         {
             <div>@Html.DisplayFor(Model => report.FacilityNumber)</div>
             <div>@Html.DisplayFor(Model => report.FacilityName)</div>
+            <div>@Html.DisplayFor(Model => report.County)</div>
+            <div class="centered-content">@Html.DisplayFor(Model => report.Class)</div>
             <div><a href="@report.SiteSummaryUrl">@Html.DisplayFor(Model => report.SiteSummaryUrl)</a></div>
         }
     </div>

--- a/FMS/Pages/Reporting/SiteSummary/SiteSummaryList.cshtml
+++ b/FMS/Pages/Reporting/SiteSummary/SiteSummaryList.cshtml
@@ -5,7 +5,7 @@
 }
 
 @{
-    ViewData["Title"] = $"Site Summary List by {Model.Spec.SortBy.ToString()}";
+    ViewData["Title"] = $"Site Summary List by {Model.Spec.GetSiteSummarySortText(Model.Spec.SortBy)}";
 }
 <div class="page-wrapper">
     <h3 class="centered-content">@ViewData["Title"]</h3>

--- a/FMS/Platform/GlobalConstants.cs
+++ b/FMS/Platform/GlobalConstants.cs
@@ -23,5 +23,9 @@
 
         // Link to Google Maps API
         public const string MapCoordLink = "https://www.google.com/maps/search/?api=1&query=";
+
+
+        public const string SiteSummaryReportPath = "/Reporting/SiteSummary/Report/";
+
     }
 }

--- a/FMS/Platform/GlobalConstants.cs
+++ b/FMS/Platform/GlobalConstants.cs
@@ -23,8 +23,5 @@
 
         // Link to Google Maps API
         public const string MapCoordLink = "https://www.google.com/maps/search/?api=1&query=";
-
-
-        public const string SiteSummaryReportPath = "/Reporting/SiteSummary/Report/";
     }
 }

--- a/FMS/wwwroot/css/report.css
+++ b/FMS/wwwroot/css/report.css
@@ -257,13 +257,17 @@ header {
 
 .summarylisthead {
     display: grid;
-    grid-template-columns: 100px 300px 400px;
+    grid-template-columns: 50px 210px 100px 40px 400px;
     font-weight: bold;
 }
 
 .summarylist {
     display: grid;
-    grid-template-columns: 100px 300px 400px;
+    grid-template-columns: 50px 210px 100px 40px 400px;
+}
+
+.centered-content {
+    text-align: center;
 }
 
 /* Footer */


### PR DESCRIPTION
Add sorting and additional columns to Site Summary list; dynamically generate PDF links
```
```
This commit enhances the Site Summary report list by adding `County` and `Class` as displayed columns and new sorting options, including `Facility Name` and `Class`. The `SiteSummaryUrl` is now dynamically constructed based on the `ASPNETCORE_ENVIRONMENT` variable, ensuring the correct PDF report is linked for Development, UAT, and Production environments.

Fixes #1063
```