### PR TITLE
1067: Correct Site Summary PDF paths and ESRI icon colors

### DIFF
--- a/FMS.Domain/DomainConstants.cs
+++ b/FMS.Domain/DomainConstants.cs
@@ -8,11 +8,11 @@ namespace FMS.Domain
     {
         public const string SiteSummaryReportPath = "/Reporting/SiteSummary/Report/";
 
-        public const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+        public const string siteSummaryReportPathPdfDev = "https://dev-fms.gaepd.org/Reporting/SiteSummary/2026/";
 
-        public const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+        public const string siteSummaryReportPathPdfProd = "https://fms.gaepd.org/Reporting/SiteSummary/2026/";
 
-        public const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/26-";
+        public const string siteSummaryReportPathPdfUat = "https://uat-fms.gaepd.org/Reporting/SiteSummary/2026/";
 
         public const string pdfSuffix = ".pdf";
     }

--- a/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
+++ b/FMS.Domain/Dto/Reports/SiteSummaryPdfListDto.cs
@@ -31,9 +31,9 @@ namespace FMS.Domain.Dto.Reports
             {
                 "A" => "small_yellow",
                 "LE" => "small_green",
-                "LI" => "small_green",
+                "LI" => "small_red",
                 "P" => "small_red",
-                "SE" => "small_red",
+                "SE" => "small_green",
                 "SI" => "small_red",
                 _ => string.Empty
             };


### PR DESCRIPTION
Updates the base URLs for Site Summary PDF reports by removing a redundant path segment, ensuring accurate link generation. Also corrects the color assignments for 'LI' (Landfill Investigation) and 'SE' (Site Investigation) status codes, which determines the corresponding ESRI map icon display.