### PR TITLE
Allow duplicate facility numbers per facility type

### DIFF
--- a/FMS.Domain/Repositories/IFacilityRepository.cs
+++ b/FMS.Domain/Repositories/IFacilityRepository.cs
@@ -17,7 +17,7 @@ namespace FMS.Domain.Repositories
         Task UpdateFacilityAsync(Guid id, FacilityEditDto facilityUpdates);
         Task DeleteFacilityAsync(Guid id);
         Task UndeleteFacilityAsync(Guid id);
-        Task<bool> FacilityNumberExists(string facilityNumber, Guid? ignoreId = null);
+        Task<bool> FacilityNumberExists(string facilityNumber, Guid facilityTypeId, Guid? ignoreId = null);
         Task<bool> DuplicateFacilityNumberExists(string newFacilityNumber, Guid oldFacilityId, Guid facilityTypeId);
         Task<bool> FileLabelExists(string fileLabel);
         Task<int> GetNextSequenceForCountyAsync(int countyId);

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -360,7 +360,7 @@ namespace FMS.Infrastructure.Repositories
 
         private async Task<Guid> CreateFacilityInternalAsync(FacilityCreateDto newFacility)
         {
-            if (await FacilityNumberExists(newFacility.FacilityNumber))
+            if (await FacilityNumberExists(newFacility.FacilityNumber, newFacility.FacilityTypeId))
             {
                 throw new ArgumentException($"Facility Number '{newFacility.FacilityNumber}' already exists.");
             }
@@ -542,9 +542,10 @@ namespace FMS.Infrastructure.Repositories
             await _context.SaveChangesAsync();
         }
 
-        public Task<bool> FacilityNumberExists(string facilityNumber, Guid? ignoreId = null) =>
+        public Task<bool> FacilityNumberExists(string facilityNumber, Guid facilityTypeId, Guid? ignoreId = null) =>
             _context.Facilities.AnyAsync(e =>
                 e.FacilityNumber == facilityNumber
+                && e.FacilityTypeId == facilityTypeId
                 && (!ignoreId.HasValue || e.Id != ignoreId.Value));
 
         public Task<bool> DuplicateFacilityNumberExists(string newFacilityNumber, Guid oldFacilityId,

--- a/FMS.Infrastructure/Repositories/FileRepository.cs
+++ b/FMS.Infrastructure/Repositories/FileRepository.cs
@@ -35,6 +35,7 @@ namespace FMS.Infrastructure.Repositories
         {
             var file = await _context.Files.AsNoTracking()
                 .Include(e => e.Facilities)
+                .ThenInclude(e => e.FacilityType)
                 .SingleOrDefaultAsync(e => e.FileLabel == fileLabel);
 
             if (file == null) return null;

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -104,7 +104,7 @@ namespace FMS.Pages.Facilities
             }
 
             // When adding a new facility number, make sure the number doesn't already exist before trying to save.
-            if (await _repository.FacilityNumberExists(Facility.FacilityNumber))
+            if (await _repository.FacilityNumberExists(Facility.FacilityNumber, Facility.FacilityTypeId))
             {
                 ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists.");
             }
@@ -192,7 +192,7 @@ namespace FMS.Pages.Facilities
             }
 
             // When adding a new facility number, make sure the number doesn't already exist before trying to save.
-            if (await _repository.FacilityNumberExists(Facility.FacilityNumber))
+            if (await _repository.FacilityNumberExists(Facility.FacilityNumber, Facility.FacilityTypeId))
             {
                 ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists.");
             }

--- a/FMS/Pages/Facilities/Add.cshtml.cs
+++ b/FMS/Pages/Facilities/Add.cshtml.cs
@@ -194,7 +194,7 @@ namespace FMS.Pages.Facilities
             // When adding a new facility number, make sure the number doesn't already exist before trying to save.
             if (await _repository.FacilityNumberExists(Facility.FacilityNumber, Facility.FacilityTypeId))
             {
-                ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists.");
+                ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists for a different Facility of this Facility Type.");
             }
 
             if (!ModelState.IsValid)

--- a/FMS/Pages/Facilities/Edit.cshtml.cs
+++ b/FMS/Pages/Facilities/Edit.cshtml.cs
@@ -134,10 +134,10 @@ namespace FMS.Pages.Facilities
                 }
             }
 
-            //for RN and HSI facilities, check for duplicate Facility Numbers
-            if ((Facility.FacilityTypeName == "RN" ||  Facility.FacilityTypeName == "HSI") && (await _repository.DuplicateFacilityNumberExists(Facility.FacilityNumber, Id, (Guid)Facility.FacilityTypeId)))
+            // check for duplicate Facility Numbers 
+            if (await _repository.DuplicateFacilityNumberExists(Facility.FacilityNumber, Id, (Guid)Facility.FacilityTypeId))
             {
-                ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists for a different Facility");
+                ModelState.AddModelError("Facility.FacilityNumber", "Facility Number entered already exists for a different Facility of this Facility Type");
             }
 
             if (!ModelState.IsValid)

--- a/FMS/Pages/Files/Details.cshtml
+++ b/FMS/Pages/Files/Details.cshtml
@@ -48,6 +48,7 @@
                 <tr>
                     <th scope="col">Facility</th>
                     <th scope="col">Name</th>
+                    <th scope="col" class="text-center">Type</th>
                     <th scope="col">Address</th>
                 </tr>
             </thead>
@@ -62,6 +63,9 @@
                         </td>
                         <td>
                             @Html.DisplayFor(m => item.Name)
+                        </td>
+                        <td class="text-center">
+                            @Html.DisplayFor(m => item.FacilityType.Name, "FacilityTypeIcon")
                         </td>
                         <td>
                             @Html.DisplayFor(m => item.Address)<br />


### PR DESCRIPTION
The uniqueness check for facility numbers now includes the facility type in its criteria. This enables the creation of facilities with the same number, provided they are associated with different facility types.

Addresses #1078.