### PR TITLE
Update NuGet packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,7 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.29.0.143774" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="[2.1.12,3.0)" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,34 +4,34 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AjaxControlToolkit" Version="20.1.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.5.0" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.8" />
     <PackageVersion Include="ClosedXML" Version="0.105.0" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="EfCore.TestSupport" Version="10.0.0" />
     <PackageVersion Include="FluentMermaid" Version="0.1.0" />
-    <PackageVersion Include="FreeSpire.PDF" Version="11.11.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="FreeSpire.PDF" Version="12.4.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageVersion Include="libphonenumber-csharp" Version="9.0.20" />
     <PackageVersion Include="LigerShark.WebOptimizer.Core" Version="3.0.477" />
     <PackageVersion Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Identity.Web" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" />
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Identity.Web" Version="4.13.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="3.0.114" />
     <PackageVersion Include="Mindscape.Raygun4Net.AspNetCore" Version="11.2.5" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.12.0" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.14.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.29.0.143774" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 </Project>

--- a/package-readme.md
+++ b/package-readme.md
@@ -1,0 +1,12 @@
+# NuGet Package maintenance
+
+Some NuGet packages have been added directly to work around vulnerable dependencies in other packages.
+
+- `System.Security.Cryptography.Xml` 10.0.10 has added to `FMS.App.Tests` to avoid a vulnerable version in
+  `Microsoft.Identity.Web`.
+
+- `System.Security.Cryptography.Xml` 10.0.10 has added to `FMS.Infrastructure.Tests` to avoid a vulnerable version in
+  `EfCore.TestSupport`.
+
+- `SQLitePCLRaw.lib.e_sqlite3` 2.1.12 has added to `FMS.Infrastructure.Tests` to avoid a vulnerable version in
+  `EfCore.TestSupport` (via `Microsoft.EntityFrameworkCore.Sqlite`).

--- a/tests/FMS.App.Tests/FMS.App.Tests.csproj
+++ b/tests/FMS.App.Tests/FMS.App.Tests.csproj
@@ -33,6 +33,7 @@
     </PackageReference>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
+++ b/tests/FMS.Infrastructure.Tests/FMS.Infrastructure.Tests.csproj
@@ -35,6 +35,7 @@
     </PackageReference>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
     <PackageReference Include="System.Security.Cryptography.Xml" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates a few NuGet packages to the latest revisions.

This PR also explicitly adds two packages that were implicitly referenced as dependencies of other packages. The implicitly referenced versions have known high severity vulnerabilities, triggering warning NU1903. I've explicitly added more recent versions that have patched the vulnerabilities.

Once the top-level packages have been updated, these dependencies can be removed. See the [package-readme.md](https://github.com/gaepdit/FMS/blob/1db9ee2944cf6999529d2f7347062f346e1365e6/package-readme.md) file for details.