### PR TITLE
Handle empty facility type selection in filters correctly

### DIFF
--- a/FMS.Domain/Dto/Facility/FacilitySpec.cs
+++ b/FMS.Domain/Dto/Facility/FacilitySpec.cs
@@ -27,7 +27,7 @@ namespace FMS.Domain.Dto
         public Guid? FacilityStatusId { get; set; }
 
         [Display(Name = "Type/Environmental Interest")]
-        public List<Guid> FacilityTypeId { get; set; }
+        public List<Guid> FacilityTypeId { get; set; } = [];
 
         [Display(Name = "Budget Code")]
         public Guid? BudgetCodeId { get; set; }

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -182,7 +182,7 @@ namespace FMS.Infrastructure.Repositories
             .Where(e => !spec.ShowPendingOnly || !e.DeterminationLetterDate.HasValue)
             .Where(e => string.IsNullOrEmpty(spec.FacilityNumber) || e.FacilityNumber.Contains(spec.FacilityNumber))
             .Where(e => !spec.FacilityStatusId.HasValue || e.FacilityStatus.Id.Equals(spec.FacilityStatusId))
-            .Where(e => spec.FacilityTypeId == null || spec.FacilityTypeId.Contains(e.FacilityType.Id))
+            .Where(e => spec.FacilityTypeId == null || spec.FacilityTypeId.Count == 0 || spec.FacilityTypeId.Contains(e.FacilityType.Id))
             .Where(e => !spec.BudgetCodeId.HasValue || e.BudgetCode.Id.Equals(spec.BudgetCodeId))
             .Where(e =>
                 !spec.OrganizationalUnitId.HasValue || e.OrganizationalUnit.Id.Equals(spec.OrganizationalUnitId))
@@ -337,7 +337,7 @@ namespace FMS.Infrastructure.Repositories
 
             // convert the List<RetentionRecord> to IEnumerable<RetentionRecordDetailDto>
             var returnList = from retentionRecord in retentionRecordsList
-                select new RetentionRecordDetailDto(retentionRecord);
+                             select new RetentionRecordDetailDto(retentionRecord);
 
             return returnList;
         }

--- a/tests/FMS.App.Tests/Facilities/FacilityEditTests.cs
+++ b/tests/FMS.App.Tests/Facilities/FacilityEditTests.cs
@@ -93,7 +93,7 @@ namespace FMS.App.Tests.Facilities
             var pageModel = new EditModel(mockRepo, mockType, mockStatus, mockSelectListHelper)
             {
                 Id = id,
-                Facility = new FacilityEditDto { Latitude = 31, Longitude = -81, FacilityNumber = "a" },
+                Facility = new FacilityEditDto { Latitude = 31, Longitude = -81, FacilityNumber = "a", FacilityTypeId = new Guid("3FE94D7D-563E-4CA1-A094-BB6E217990D2") },
                 PageContext = pageContext,
             };
 

--- a/tests/FMS.Infrastructure.Tests/FacilityRepositoryTests.cs
+++ b/tests/FMS.Infrastructure.Tests/FacilityRepositoryTests.cs
@@ -284,7 +284,7 @@ namespace FMS.Infrastructure.Tests
         public async Task FacilityNumberExists_Unique_ReturnsFalse()
         {
             using var repository = (await CreateRepositoryHelperAsync()).GetFacilityRepository();
-            var result = await repository.FacilityNumberExists("Unique");
+            var result = await repository.FacilityNumberExists("Unique", Guid.NewGuid());
             result.Should().BeFalse();
         }
 
@@ -292,8 +292,8 @@ namespace FMS.Infrastructure.Tests
         public async Task FacilityNumberExists_Duplicate_ReturnsTrue()
         {
             using var repository = (await CreateRepositoryHelperAsync()).GetFacilityRepository();
-
-            var result = await repository.FacilityNumberExists("UTF8");
+            var facTypeId = new Guid("3FE94D7D-563E-4CA1-A094-BB6E217990D2");
+            var result = await repository.FacilityNumberExists("UTF8", facTypeId);
 
             result.Should().BeTrue();
         }
@@ -303,8 +303,9 @@ namespace FMS.Infrastructure.Tests
         {
             using var repository = (await CreateRepositoryHelperAsync()).GetFacilityRepository();
             var ignoreId = SeedData.GetFacilities()[0].Id;
+            var facTypeId = SeedData.GetFacilityTypes()[0].Id;
             var facName = SeedData.GetFacilities()[0].Name;
-            var result = await repository.FacilityNumberExists(facName, ignoreId);
+            var result = await repository.FacilityNumberExists(facName, facTypeId, ignoreId);
             result.Should().BeFalse();
         }
 


### PR DESCRIPTION
Previously, when no facility types were selected in the filter specification (e.g., for an export), the query would inadvertently return no results. This update initializes `FacilityTypeId` to an empty list and ensures that an empty list bypasses the filter, allowing all facility types to be included. This resolves an issue with the Excel export button where no data was returned if the facility type filter was empty.