### PR TITLE
Enhance VRP Facility Details page and add null checks

### DIFF
--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -384,7 +384,7 @@
         <div class="container bg-light-subtle p-3 m-1 rounded-3">
             <nav class="navbar navbar-expand-sm">
                 <ul class="nav nav-tabs active" id="HSINavBar">
-                    @if (Model.FacilityDetail.FacilityType.Name == "HSI")
+                    @if (Model.FacilityDetail.FacilityType.Name == "HSI" || Model.FacilityDetail.FacilityType.Name == "VRP")
                     {
                         <li class="nav-item" role="presentation">
                             <a class="nav-link @(Model.ActiveTab == "HSIProperties" ? "active" : "")" data-bs-toggle="tab" data-bs-target="#HSIProperties" type="text/html" role="tab" aria-controls="HSIProperties" aria-selected="@(Model.FacilityDetail.FacilityType.Name == "VRP" ? "false" : "true")" href="#HSIProperties">HSI Properties</a>
@@ -406,13 +406,21 @@
                         </li>
                     }
                     <li class="nav-item" role="presentation">
-                        <a class="nav-link @(Model.ActiveTab == "Events" || (((Model.FacilityDetail.FacilityType.Name == "RN" || Model.FacilityDetail.FacilityType.Name == "VRP") && (Model.FacilityDetail.FacilityStatus.Name == "COMPLAINT" || Model.FacilityDetail.FacilityStatus.Name == "Event Tracking On")) || (Model.FacilityDetail.FacilityType.Name == "NPL" && Model.FacilityDetail.FacilityStatus.Name == "EPA Referred")) ? "active" : "")" data-bs-toggle="tab" data-bs-target="#Events" type="text/html" role="tab" aria-controls="Events" aria-selected="@((((Model.FacilityDetail.FacilityType.Name == "RN" || Model.FacilityDetail.FacilityType.Name == "VRP") && (Model.FacilityDetail.FacilityStatus.Name == "COMPLAINT" || Model.FacilityDetail.FacilityStatus.Name == "Event Tracking On")) || (Model.FacilityDetail.FacilityType.Name == "NPL" && Model.FacilityDetail.FacilityStatus.Name == "EPA Referred")) ? "true" : "false")" href="#Events">Events</a>
+                        <a class="nav-link @(Model.ActiveTab == "Events" ? "active" : "")"
+                        @* || (((Model.FacilityDetail.FacilityType.Name= ="RN" || Model.FacilityDetail.FacilityType.Name= ="VRP" ) && (Model.FacilityDetail.FacilityStatus.Name= ="COMPLAINT" || Model.FacilityDetail.FacilityStatus.Name= ="Event Tracking On" )) || (Model.FacilityDetail.FacilityType.Name= ="NPL" && Model.FacilityDetail.FacilityStatus.Name= ="EPA Referred" )) ? "active" : "" )" *@
+                           data-bs-toggle="tab"
+                           data-bs-target="#Events"
+                           type="text/html"
+                           role="tab"
+                           aria-controls="Events"
+                           aria-selected=" @(Model.ActiveTab == "Events" ? "active" : "")"
+                        @* ((((Model.FacilityDetail.FacilityType.Name == "RN" || Model.FacilityDetail.FacilityType.Name == "VRP") && (Model.FacilityDetail.FacilityStatus.Name == "COMPLAINT" || Model.FacilityDetail.FacilityStatus.Name == "Event Tracking On")) || (Model.FacilityDetail.FacilityType.Name == "NPL" && Model.FacilityDetail.FacilityStatus.Name == "EPA Referred")) ? "true" : "false")" *@ href="#Events">Events</a>
                     </li>
                 </ul>
             </nav>
 
             <div class="tab-content">
-                @if (Model.FacilityDetail.FacilityType.Name == "HSI")
+                @if (Model.FacilityDetail.FacilityType.Name == "HSI" || Model.FacilityDetail.FacilityType.Name == "VRP")
                 {
                     <div class="tab-pane @(Model.ActiveTab == "HSIProperties" ? "active" : "")" id="HSIProperties" role="tabpanel" aria-labelledby="HSIProperties-tab">
                         <H3>
@@ -1427,7 +1435,7 @@
                             <div class="col-md-4">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.Lien)
                             </div>
-                            @if (Model.FacilityDetail.StatusDetails.Lien)
+                            @if (Model.FacilityDetail.StatusDetails != null && Model.FacilityDetail.StatusDetails.Lien)
                             {
                                 <div class="col-md-3">
                                     <a href="https://gets.sharepoint.com/:f:/s/ResponseandRemediationProgram/EhLSMRi5lEZOquQ6pLKhLUwBEpMsALxr5BHdhIOp6kZYiw?e=5vWBcz" class="btn btn-sm btn-primary" target="_blank">Liens Filed with County</a>
@@ -1444,7 +1452,7 @@
                             <div class="col-md-4">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.FinancialAssurance)
                             </div>
-                            @if (Model.FacilityDetail.StatusDetails.FinancialAssurance)
+                            @if (Model.FacilityDetail.StatusDetails != null && Model.FacilityDetail.StatusDetails.FinancialAssurance)
                             {
                                 <div class="col-md-3">
                                     <a href="https://gets.sharepoint.com/:x:/r/sites/ResponseandRemediationProgram/_layouts/15/Doc.aspx?sourcedoc=%7B3A30C17D-62E2-4F54-BB79-F60CAF3EBC98%7D&file=HSRP%20Financial%20Assurance%20List%20of%20Sites%202020.xlsx&action=default&mobileredirect=true" class="btn btn-sm btn-primary" target="_blank">HSRP Financial Assurance Tracker</a>
@@ -1458,7 +1466,7 @@
                             <div class="col-md-4">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.UEC)
                             </div>
-                            @if (Model.FacilityDetail.StatusDetails.UEC)
+                            @if (Model.FacilityDetail.StatusDetails != null && Model.FacilityDetail.StatusDetails.UEC)
                             {
                                 <div class="col-md-3">
                                     <a href="https://epd.georgia.gov/properties-subject-uniform-environmental-covenants" class="btn btn-sm btn-primary" target="_blank">EC Online Knack Table</a>
@@ -1467,7 +1475,11 @@
                         </div>
                     </div>
                 }
-                <div class="tab-pane @(Model.ActiveTab == "Events" || (((Model.FacilityDetail.FacilityType.Name == "RN" || Model.FacilityDetail.FacilityType.Name == "VRP") && (Model.FacilityDetail.FacilityStatus.Name == "COMPLAINT" || Model.FacilityDetail.FacilityStatus.Name == "Event Tracking On")) || (Model.FacilityDetail.FacilityType.Name == "NPL" && Model.FacilityDetail.FacilityStatus.Name == "EPA Referred")) ? "active" : "")" id="Events" role="tabpanel" aria-labelledby="Events-tab">
+                <div class="tab-pane @(Model.ActiveTab == "Events" ? "active" : "")"
+                    @* || (((Model.FacilityDetail.FacilityType.Name= ="RN" || Model.FacilityDetail.FacilityType.Name= ="VRP" ) && (Model.FacilityDetail.FacilityStatus.Name= ="COMPLAINT" || Model.FacilityDetail.FacilityStatus.Name= ="Event Tracking On" )) || (Model.FacilityDetail.FacilityType.Name= ="NPL" && Model.FacilityDetail.FacilityStatus.Name= ="EPA Referred" )) ? "active" : "" )" *@
+                     id="Events"
+                     role="tabpanel"
+                     aria-labelledby="Events-tab">
                     <h3>
                         <form method="post">
                             Events

--- a/FMS/Pages/Facilities/Details.cshtml.cs
+++ b/FMS/Pages/Facilities/Details.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using FMS.Domain.Dto;
+using FMS.Domain.Dto;
 using FMS.Domain.Repositories;
 using FMS.Helpers;
 using FMS.Platform.Extensions;
@@ -66,6 +66,8 @@ namespace FMS.Pages.Facilities
         public string Lon { get; set; }
 
         public EventSort SortBy { get; set; }
+
+        public bool IsVrpTracked { get; set; }
 
         public async Task<IActionResult> OnGetAsync(Guid? id, Guid? hr, string tab, EventSort sortBy = EventSort.StartDateDesc)
         {
@@ -187,11 +189,22 @@ namespace FMS.Pages.Facilities
 
         public string GetGoogleMapsUrl(FacilityDetailDto facility)
         {
-            if (facility.Latitude != 0 && facility.Longitude != 0)
+            if (facility.Latitude != 0 && facility.Longitude != 0 && facility.LocationDetails != null)
             {
                 return $"https://maps.googleapis.com/maps/api/staticmap?center={facility.Latitude},{facility.Longitude}&zoom={facility.LocationDetails.MapZoom}&size=250x250&markers=color:red|{facility.Latitude},{facility.Longitude}&maptype={facility.LocationDetails.MapType}&key={GoogleMapsApiKey}&style=feature:poi|visibility:off";
             }
             return null;
+        }
+
+        public bool GetVrpTrackingStatus(FacilityDetailDto facility)
+        {
+            if (facility != null &&
+                facility.HsrpFacilityPropertyDetails.VRPDate != null &&
+                !facility.HsrpFacilityPropertyDetails.VRPTerminated)
+            {
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
This update expands the "HSI Properties" tab visibility to VRP facility types and simplifies the conditional activation of the "Events" tab. Additionally, null checks were added for `StatusDetails` and `LocationDetails` to prevent potential runtime errors, improving the page's overall robustness. A new `GetVrpTrackingStatus` helper method was also introduced.