### PR TITLE
Fix #1098: Enhance event property display for null values

### DIFF
--- a/FMS.Domain/Dto/AllowedActionTaken/AllowedActionTakenSpec.cs
+++ b/FMS.Domain/Dto/AllowedActionTaken/AllowedActionTakenSpec.cs
@@ -26,24 +26,24 @@ namespace FMS.Domain.Dto
         public bool Active { get; set; }
 
         [Display(Name = "Start Date Required")]
-        public bool StartDateRequired { get; set; }
+        public bool StartDateRequired { get; set; } = false;
 
         [Display(Name = "Due Date Required")]
-        public bool DueDateRequired { get; set; }
+        public bool DueDateRequired { get; set; } = false;
 
         [Display(Name = "Completion Date Required")]
-        public bool CompletionDateRequired { get; set; }
+        public bool CompletionDateRequired { get; set; } = false;
 
         public Guid EventTypeId { get; set; }
 
         public string EventTypeName { get; set; }
 
-        public bool EventTypeActive { get; set; }
+        public bool EventTypeActive { get; set; } = false;
 
         public Guid ActionTakenId { get; set; }
 
         public string ActionTakenName { get; set; } 
 
-        public bool ActionTakenActive { get; set; }
+        public bool ActionTakenActive { get; set; } = false;
     }
 }

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -318,6 +318,8 @@ namespace FMS.Infrastructure.Repositories
                 TypeList = JsonSerializer.Serialize(spec.FacilityTypeId);
             }
 
+
+
             return (await conn.QueryAsync<FacilityMapSummaryDto>("dbo.getNearbyFacilities",
                 new { Active = !spec.ShowDeleted, spec.Latitude, spec.Longitude, spec.Radius, TypeList },
                 commandType: CommandType.StoredProcedure)).ToList();

--- a/FMS.Infrastructure/Repositories/FacilityRepository.cs
+++ b/FMS.Infrastructure/Repositories/FacilityRepository.cs
@@ -318,8 +318,6 @@ namespace FMS.Infrastructure.Repositories
                 TypeList = JsonSerializer.Serialize(spec.FacilityTypeId);
             }
 
-
-
             return (await conn.QueryAsync<FacilityMapSummaryDto>("dbo.getNearbyFacilities",
                 new { Active = !spec.ShowDeleted, spec.Latitude, spec.Longitude, spec.Radius, TypeList },
                 commandType: CommandType.StoredProcedure)).ToList();

--- a/FMS/Pages/Event/Add.cshtml
+++ b/FMS/Pages/Event/Add.cshtml
@@ -52,12 +52,25 @@
                                 <td>@Html.DisplayFor(m => item.StartDate)</td>
                                 <td>@Html.DisplayFor(m => item.DueDate)</td>
                                 <td>@Html.DisplayFor(m => item.CompletionDate)</td>
-                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
+                                <td>
+                                    @if (item.ComplianceOfficer != null)
+                                    {
+                                        @Html.DisplayFor(m => item.ComplianceOfficer.Name)
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">N/A</span>
+                                    }
+                                </td>
                                 <td>@Html.DisplayFor(m => item.EventAmount)</td>
                                 <td>
                                     @if (item.EventContractor != null)
                                     {
                                         @Html.DisplayFor(m => item.EventContractor.Name)
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">N/A</span>
                                     }
                                 </td>
                                 <td>@Html.DisplayFor(m => item.Comment)</td>
@@ -233,12 +246,25 @@
                                 <td>@Html.DisplayFor(m => item.StartDate)</td>
                                 <td>@Html.DisplayFor(m => item.DueDate)</td>
                                 <td>@Html.DisplayFor(m => item.CompletionDate)</td>
-                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
+                                <td>
+                                    @if (item.ComplianceOfficer != null)
+                                    {
+                                        @Html.DisplayFor(m => item.ComplianceOfficer.Name)
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">N/A</span>
+                                    }
+                                </td>
                                 <td style="text-align:right">@Html.DisplayFor(m => item.EventAmount)</td>
                                 <td>
                                     @if (item.EventContractor != null)
                                     {
                                         @Html.DisplayFor(m => item.EventContractor.Name)
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">N/A</span>
                                     }
                                 </td>
                                 <td>@Html.DisplayFor(m => item.Comment)</td>

--- a/FMS/Pages/Event/Add.cshtml.cs
+++ b/FMS/Pages/Event/Add.cshtml.cs
@@ -133,6 +133,7 @@ namespace FMS.Pages.Event
                 Events = await _repository.GetEventsByFacilityIdAsync(Id);
                 Events = EventSortHelper.SortEvents(Events, SortBy);
                 AllowedActionTakenSpec = await _allowedActionTakenRepository.GetAllowedActionTakenByEventTypeAndActionTakenAsync(NewEvent.EventTypeId, NewEvent.ActionTakenId);
+                AllowedActionTakenSpec ??= new AllowedActionTakenSpec();
                 await PopulateSelectsAsync();
                 return Page();
             }
@@ -152,6 +153,7 @@ namespace FMS.Pages.Event
                 Events = await _repository.GetEventsByFacilityIdAsync(Id);
                 Events = EventSortHelper.SortEvents(Events, SortBy);
                 AllowedActionTakenSpec = await _allowedActionTakenRepository.GetAllowedActionTakenByEventTypeAndActionTakenAsync(NewEvent.EventTypeId, NewEvent.ActionTakenId);
+                AllowedActionTakenSpec ??= new AllowedActionTakenSpec();
                 await PopulateSelectsAsync();
                 return Page();
             }

--- a/FMS/Pages/Event/Edit.cshtml
+++ b/FMS/Pages/Event/Edit.cshtml
@@ -39,30 +39,31 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach (var item in Model.Facility.Events)
+                        @for (var i = 0; i < Model.Events.Count; i++)
                         {
-                            if (item.EventType.Name == "HWTF Master Project")
+                            var item = Model.Events[i];
+                            if (item.EventType?.Name == "HWTF Master Project")
                             {
                                 <tr class="@(item.Id == Model.Id ? " table-danger" : "")">
                                     <td class="text-nowrap">
                                         <label>
                                             @Html.RadioButtonFor(m => m.EditEvent.ParentId, item.Id)
-                                            @Html.DisplayFor(m => item.EventType.Name)
+                                            @Html.DisplayFor(m => item.EventType.Name, "StringOrNone")
                                         </label>
                                     </td>
-                                    <td>@Html.DisplayFor(m => item.ActionTaken.Name)</td>
-                                    <td>@Html.DisplayFor(m => item.StartDate)</td>
-                                    <td>@Html.DisplayFor(m => item.DueDate)</td>
-                                    <td>@Html.DisplayFor(m => item.CompletionDate)</td>
-                                    <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
-                                    <td>@Html.DisplayFor(m => item.EventAmount)</td>
+                                    <td>@Html.DisplayFor(m => item.ActionTaken.Name, "StringOrNone")</td>
+                                    <td>@Html.DisplayFor(m => item.StartDate, "DateOrNone")</td>
+                                    <td>@Html.DisplayFor(m => item.DueDate, "DateOrNone")</td>
+                                    <td>@Html.DisplayFor(m => item.CompletionDate, "DateOrNone")</td>
+                                    <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")</td>
+                                    <td>@Html.DisplayFor(m => item.EventAmount, "DecimalOrNone")</td>
                                     <td>
                                         @if (item.EventContractor != null)
                                         {
-                                            @Html.DisplayFor(m => item.EventContractor.Name)
+                                            @Html.DisplayFor(m => item.EventContractor.Name, "StringOrNone")
                                         }
                                     </td>
-                                    <td>@Html.DisplayFor(m => item.Comment)</td>
+                                    <td>@Html.DisplayFor(m => item.Comment, "StringOrNone")</td>
                                 </tr>
                             }
                         }
@@ -239,27 +240,27 @@
                         @for (var i = 0; i < Model.Events.Count; i++)
                         {
                             var item = Model.Events[i];
-                            <tr class="@((item.ParentId != Guid.Empty ? "text-muted table-warning" : "") + (item.EventType.Name == "HWTF Master Project" ? " table-info" : "") + (item.Id == Model.Id ? " table-danger" : ""))">
+                            <tr class="@((item.ParentId != Guid.Empty ? "text-muted table-warning" : "") + (item.EventType?.Name == "HWTF Master Project" ? " table-info" : "") + (item.Id == Model.Id ? " table-danger" : ""))">
                                 <td>
                                     @if (item.ParentId != Guid.Empty)
                                     {
                                         <span class="badge text-bg-info"> ^ </span>
                                     }
-                                    @Html.DisplayFor(m => item.EventType.Name)
+                                    @Html.DisplayFor(m => item.EventType.Name, "StringOrNone")
                                 </td>
-                                <td>@Html.DisplayFor(m => item.ActionTaken.Name)</td>
-                                <td>@Html.DisplayFor(m => item.StartDate)</td>
-                                <td>@Html.DisplayFor(m => item.DueDate)</td>
-                                <td>@Html.DisplayFor(m => item.CompletionDate)</td>
-                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name)</td>
-                                <td style="text-align:right">@Html.DisplayFor(m => item.EventAmount)</td>
+                                <td>@Html.DisplayFor(m => item.ActionTaken.Name, "StringOrNone")</td>
+                                <td>@Html.DisplayFor(m => item.StartDate, "DateOrNone")</td>
+                                <td>@Html.DisplayFor(m => item.DueDate, "DateOrNone")</td>
+                                <td>@Html.DisplayFor(m => item.CompletionDate, "DateOrNone")</td>
+                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")</td>
+                                <td style="text-align:right">@Html.DisplayFor(m => item.EventAmount, "DecimalOrNone")</td>
                                 <td>
                                     @if (item.EventContractor != null)
                                     {
-                                        @Html.DisplayFor(m => item.EventContractor.Name)
+                                        @Html.DisplayFor(m => item.EventContractor.Name, "StringOrNone")
                                     }
                                 </td>
-                                <td>@Html.DisplayFor(m => item.Comment)</td>
+                                <td>@Html.DisplayFor(m => item.Comment, "StringOrNone")</td>
                             </tr>
                         }
                     </tbody>

--- a/FMS/Pages/Event/Edit.cshtml
+++ b/FMS/Pages/Event/Edit.cshtml
@@ -39,9 +39,8 @@
                         </tr>
                     </thead>
                     <tbody>
-                        @for (var i = 0; i < Model.Events.Count; i++)
+                        @foreach (var item in Model.Events)
                         {
-                            var item = Model.Events[i];
                             if (item.EventType?.Name == "HWTF Master Project")
                             {
                                 <tr class="@(item.Id == Model.Id ? " table-danger" : "")">
@@ -55,12 +54,24 @@
                                     <td>@Html.DisplayFor(m => item.StartDate, "DateOrNone")</td>
                                     <td>@Html.DisplayFor(m => item.DueDate, "DateOrNone")</td>
                                     <td>@Html.DisplayFor(m => item.CompletionDate, "DateOrNone")</td>
-                                    <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")</td>
+                                    <td>@if(item.ComplianceOfficer != null)
+                                        {
+                                            @Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted">None</span>
+                                        }   
+                                    </td>
                                     <td>@Html.DisplayFor(m => item.EventAmount, "DecimalOrNone")</td>
                                     <td>
                                         @if (item.EventContractor != null)
                                         {
                                             @Html.DisplayFor(m => item.EventContractor.Name, "StringOrNone")
+                                        }
+                                        else
+                                        {
+                                            <span class="text-muted">None</span>
                                         }
                                     </td>
                                     <td>@Html.DisplayFor(m => item.Comment, "StringOrNone")</td>
@@ -109,7 +120,8 @@
                 <span asp-validation-for="EditEvent.StartDate" class="text-danger"></span>
             </div>
             <div class="col">
-                <label asp-for="EditEvent.DueDate" class="form-label">Event Due Date <span class="text-danger"> @(Model.AllowedActionTakenSpec.DueDateRequired ? "*" : "")</span>
+                <label asp-for="EditEvent.DueDate" class="form-label">
+                    Event Due Date <span class="text-danger"> @(Model.AllowedActionTakenSpec.DueDateRequired ? "*" : "")</span>
                 </label>
                 <input asp-for="EditEvent.DueDate" class="form-control datepicker" type="date" placeholder="" />
                 <span asp-validation-for="EditEvent.DueDate" class="text-danger"></span>
@@ -117,7 +129,8 @@
         </div>
         <div class="row">
             <div class="col">
-                <label asp-for="EditEvent.CompletionDate" class="form-label">Event Completion Date <span class="text-danger"> @(Model.AllowedActionTakenSpec.CompletionDateRequired ? "*" : "")</span>
+                <label asp-for="EditEvent.CompletionDate" class="form-label">
+                    Event Completion Date <span class="text-danger"> @(Model.AllowedActionTakenSpec.CompletionDateRequired ? "*" : "")</span>
                 </label>
                 <input asp-for="EditEvent.CompletionDate" class="form-control datepicker" type="date" placeholder="" />
                 <span asp-validation-for="EditEvent.CompletionDate" class="text-danger"></span>
@@ -152,12 +165,12 @@
         <hr />
         <p class="text-danger">* denotes a required field</p>
         <button type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Save Event</button>
-        <a asp-page="../Facilities/Details" 
-            asp-route-Id="@Model.EditEvent.FacilityId"
-            asp-route-tab="Events"
-            asp-route-sortBy = "@Model.SortBy"
+        <a asp-page="../Facilities/Details"
+           asp-route-Id="@Model.EditEvent.FacilityId"
+           asp-route-tab="Events"
+           asp-route-sortBy="@Model.SortBy"
            asp-fragment="TabPages"
-            class="btn btn-outline-secondary col-md-2">
+           class="btn btn-outline-secondary col-md-2">
             Cancel
         </a>
     </div>
@@ -172,10 +185,10 @@
                     <input type="hidden" asp-for="EditEvent.ParentId" />
                     <input type="hidden" asp-for="EditEvent.Id" />
                     <input type="hidden" asp-for="EditEvent.Active" />
-                    <button id="ExportButton" 
-                        asp-page-handler="ExportButton"
-                        asp-route-sortBy="@Model.SortBy" 
-                        class="btn btn-sm btn-outline-primary mb-1">
+                    <button id="ExportButton"
+                            asp-page-handler="ExportButton"
+                            asp-route-sortBy="@Model.SortBy"
+                            class="btn btn-sm btn-outline-primary mb-1">
                         Excel Export
                     </button>
                 </form>
@@ -252,12 +265,25 @@
                                 <td>@Html.DisplayFor(m => item.StartDate, "DateOrNone")</td>
                                 <td>@Html.DisplayFor(m => item.DueDate, "DateOrNone")</td>
                                 <td>@Html.DisplayFor(m => item.CompletionDate, "DateOrNone")</td>
-                                <td>@Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")</td>
+                                <td>
+                                    @if (item.ComplianceOfficer != null)
+                                    {
+                                        @Html.DisplayFor(m => item.ComplianceOfficer.Name, "StringOrNone")
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">None</span>
+                                    }
+                                </td>
                                 <td style="text-align:right">@Html.DisplayFor(m => item.EventAmount, "DecimalOrNone")</td>
                                 <td>
                                     @if (item.EventContractor != null)
                                     {
                                         @Html.DisplayFor(m => item.EventContractor.Name, "StringOrNone")
+                                    }
+                                    else
+                                    {
+                                        <span class="text-muted">None</span>
                                     }
                                 </td>
                                 <td>@Html.DisplayFor(m => item.Comment, "StringOrNone")</td>

--- a/FMS/Pages/Event/Edit.cshtml.cs
+++ b/FMS/Pages/Event/Edit.cshtml.cs
@@ -38,7 +38,7 @@ namespace FMS.Pages.Event
         public EventEditDto EditEvent { get; set; }
 
         [BindProperty]
-        public AllowedActionTakenSpec AllowedActionTakenSpec { get; set; }    
+        public AllowedActionTakenSpec AllowedActionTakenSpec { get; set; }   
 
         public FacilityDetailDto Facility { get; set; }
 
@@ -71,7 +71,9 @@ namespace FMS.Pages.Event
             {
                 return NotFound();
             }
+
             AllowedActionTakenSpec = await _allowedActionTakenRepository.GetAllowedActionTakenByEventTypeAndActionTakenAsync((Guid)EditEvent.EventTypeId, (Guid)EditEvent.ActionTakenId);
+            AllowedActionTakenSpec ??= new AllowedActionTakenSpec();
 
             Facility = await _facilityRepository.GetFacilityAsync(EditEvent.FacilityId);
 

--- a/FMS/Pages/Facilities/Map.cshtml.cs
+++ b/FMS/Pages/Facilities/Map.cshtml.cs
@@ -134,6 +134,14 @@ namespace FMS.Pages.Facilities
 
         {
             var fileName = $"FMS_Map_export{DateTime.Now:yyyy-MM-dd.HH-mm-ss.FFF}.xlsx";
+            if (Spec.Latitude == null && Spec.GeocodeLat != null)
+            {
+                Spec.Latitude = decimal.Parse(Spec.GeocodeLat);
+            }
+            if (Spec.Longitude == null && Spec.GeocodeLng != null)
+            {
+                Spec.Longitude = decimal.Parse(Spec.GeocodeLng);
+            }
             IReadOnlyList<FacilityMapSummaryDto> facilityMapSummaries = await _repository.GetFacilityListAsync(Spec);
             var facilityMapDetail = from p in facilityMapSummaries select new FacilityMapSummaryDtoScalar(p);
             return File(facilityMapDetail.ExportExcelAsByteArray(ExportHelper.ReportType.Map), "application/vnd.ms.excel", fileName);


### PR DESCRIPTION
Implement null-conditional operators and specific display templates (e.g., 'StringOrNone', 'DateOrNone', 'DecimalOrNone') to prevent `NullReferenceException` errors and ensure consistent, readable presentation of event data, even when properties are missing.