### PR TITLE
Add tooltips for score and groundwater score fields

### DIFF
--- a/FMS/Helpers/ToolTipHelper.cs
+++ b/FMS/Helpers/ToolTipHelper.cs
@@ -2,11 +2,11 @@
 
 namespace FMS.Helpers
 {
-    public class ScoreToolTipHelper
+    public static class ScoreToolTipHelper
     {
         public const string Score = "<a href='https://gets.sharepoint.com/:x:/r/sites/RRP-Templates/Shared%20Documents/Release_Notifications%20and%20HSI%20Listing/RQSM%20Scoresheet%20Calculator.xls?d=w40774f5702564932b0fd2b78055b9b6e&csf=1&web=1&e=AdKkR3' target='_blank'>Please see RQSM Score Sheet Calculator</a>";
     }
-    public class GWToolTipHelper
+    public static class GWToolTipHelper
     {
         public const string GWScore = "Score > 10 Site listed to HSI for impacts to groundwater";
         public const string AReleaseType = "(45) Known Release, (10) Suspected Release, (5) Potential Future Release";
@@ -18,5 +18,18 @@ namespace FMS.Helpers
         public const string D3Quantity = "Mass of the regulated substance released - (1) low, (2), (3), (4) default, (5), (6), (7), (8) high";
         public const string E1Exposure = "<a href='https://gets.sharepoint.com/:x:/r/sites/RRP-Templates/Shared%20Documents/Release_Notifications%20and%20HSI%20Listing/RQSM%20Scoresheet%20Calculator.xls?d=w40774f5702564932b0fd2b78055b9b6e&csf=1&web=1&e=AdKkR3' target='_blank'>Please see RQSM Score Sheet Calculator</a>";
         public const string E2DistanceToWell = "Distance from known location of regulated substance to drinking water well in presumed flowpath - (16) < 1/2 Mile, (9) 1/2-1 mile, (4) 1-2 miles, (1) 2-3 miles, (0) > 3 miles";
+    }
+
+    public static class OnsiteToolTipHelper
+    {
+        public const string OSScore = "Score > 20 Site listed to HSI for impacts to soil";
+        public const string AAccessToSite = "(0) Inaccessible, (2) Limited access, (4) Unlimited access";
+        public const string BReleaseType = "(25) Known Release, (15) Suspected Release, (0) No Release";
+        public const string CContainment = "(0) Covered by permanent non-earthern material, (1) Covered by engineered material, (2) Covered by loose earthen fill or native soil, (3) No Cover";
+        public const string ChemicalName = "Regulated substance used for on-site evaluation";
+        public const string D2ToxVal = "Toxicity Value of regulated substance - (1) None/low, (2), (4), (8), (16) High";
+        public const string D3Quantity = "Mass of the regulated substance released - (1) low, (2), (3), (4) default, (5), (6), (7), (8) high";
+        public const string E1DistanceToResidence = "Measured from outer edge of affected area to nearest residence, day care, school, playground - (8) < 300ft, (6) 301-1000ft,  (4) 1001-3000ft, (2) 3001-5280ft, (1) > 1 mile";
+        public const string E2SensitiveEnvironment = "Sensitive area must lie within the area of a regulated substance and be likely to be affected by the release - (1) Yes, (0) No";
     }
 }

--- a/FMS/Helpers/ToolTipHelper.cs
+++ b/FMS/Helpers/ToolTipHelper.cs
@@ -32,4 +32,17 @@ namespace FMS.Helpers
         public const string E1DistanceToResidence = "Measured from outer edge of affected area to nearest residence, day care, school, playground - (8) < 300ft, (6) 301-1000ft,  (4) 1001-3000ft, (2) 3001-5280ft, (1) > 1 mile";
         public const string E2SensitiveEnvironment = "Sensitive area must lie within the area of a regulated substance and be likely to be affected by the release - (1) Yes, (0) No";
     }
+
+    public static class StatusToolTipHelper
+    {
+        public const string ISWQS = "Above In-Stream Water Quality Standards?";
+        public const string SourceStatus = "ABND - Abandoned, CIP - Cleanup in Progress, INAC - Inactive Site, INV - Investigation Phase, NAT - No Action Taken, NFA - No Further Action, RRS# - Meets Type # RRS";
+        public const string SoilStatus = "ABND - Abandoned, CIP - Cleanup in Progress, INAC - Inactive Site, INV - Investigation Phase, NAT - No Action Taken, NFA - No Further Action, RRS# - Meets Type # RRS";
+        public const string GroundwaterStatus = "ABND - Abandoned, CIP - Cleanup in Progress, INAC - Inactive Site, INV - Investigation Phase, NAT - No Action Taken, NFA - No Further Action, RRS# - Meets Type # RRS";
+        public const string OverallStatus = "ABND - Abandoned, CIP - Cleanup in Progress, INAC - Inactive Site, INV - Investigation Phase, NAT - No Action Taken, NFA - No Further Action, RRS# - Meets Type # RRS";
+        public const string GAPSModelScore = "110 or above = High Priority, 70-109 = Medium Priority, 30-69 = Low Priority, 0-30 = Discuss with Unit Coordinator";
+        public const string CostEstimate = "RACER estimate";
+        public const string FundingSource = "A- Abandoned, LE - Local Government Eligible, LI - Local Government Ineligible, P - Private Party, SE - State Government Eligible, SI - State Government Ineligible";
+        public const string GAPSAssessment = "Threat Site may pose to human health or the environment";
+    }
 }

--- a/FMS/Helpers/ToolTipHelper.cs
+++ b/FMS/Helpers/ToolTipHelper.cs
@@ -1,0 +1,22 @@
+﻿using FMS.Domain.Entities;
+
+namespace FMS.Helpers
+{
+    public class ScoreToolTipHelper
+    {
+        public const string Score = "<a href='https://gets.sharepoint.com/:x:/r/sites/RRP-Templates/Shared%20Documents/Release_Notifications%20and%20HSI%20Listing/RQSM%20Scoresheet%20Calculator.xls?d=w40774f5702564932b0fd2b78055b9b6e&csf=1&web=1&e=AdKkR3' target='_blank'>Please see RQSM Score Sheet Calculator</a>";
+    }
+    public class GWToolTipHelper
+    {
+        public const string GWScore = "Score > 10 Site listed to HSI for impacts to groundwater";
+        public const string AReleaseType = "(45) Known Release, (10) Suspected Release, (5) Potential Future Release";
+        public const string B1Susceptibility = "Pollution susceptibility of area according to Hydrologic Atlas 20 - (6) Higher, (3) Average, (0) Lower ";
+        public const string B2PhysicalState = "Physical state of the released substance during initial release - (0) Stable Solid, (1) Unstable Solid, (2) Powder/Ash, (3) Liquid/Gas/Sludge";
+        public const string CContainment = "Measure of physical barriers preventing regulated substance from migrating - (0) Very Good, (1) Good, (2) Fair, (3) Poor";
+        public const string ChemicalName = "Regulated substance used for groundwater evaluation";
+        public const string D2ToxVal = "Toxicity Value of regulated substance - (1) None/low, (2), (4), (8), (16) High";
+        public const string D3Quantity = "Mass of the regulated substance released - (1) low, (2), (3), (4) default, (5), (6), (7), (8) high";
+        public const string E1Exposure = "<a href='https://gets.sharepoint.com/:x:/r/sites/RRP-Templates/Shared%20Documents/Release_Notifications%20and%20HSI%20Listing/RQSM%20Scoresheet%20Calculator.xls?d=w40774f5702564932b0fd2b78055b9b6e&csf=1&web=1&e=AdKkR3' target='_blank'>Please see RQSM Score Sheet Calculator</a>";
+        public const string E2DistanceToWell = "Distance from known location of regulated substance to drinking water well in presumed flowpath - (16) < 1/2 Mile, (9) 1/2-1 mile, (4) 1-2 miles, (1) 2-3 miles, (0) > 3 miles";
+    }
+}

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -1,11 +1,13 @@
 @page "{id:Guid?}"
 @using FMS.Domain.Dto
 @using FMS.Domain.Entities.Users
+@using FMS.Helpers
 @model FMS.Pages.Facilities.DetailsModel
 
 @section Scripts {
     <partial name="_ValidationScriptsPartial" />
     <script src="~/js/formDetails.js"></script>
+    <script src="~/js/tooltip.js"></script>
 }
 
 @{
@@ -690,6 +692,19 @@
                                 <a asp-page="/Score/Edit" asp-route-id="@Model.FacilityDetail.Id" class="btn btn-sm btn-primary">Edit Score</a>
                             }
                         </h3>
+                        <button id="Score-help-button"
+                                type="button"
+                                style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                                aria-details="Score-tooltip-text"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="bottom"
+                                data-bs-html="true"
+                                title="@ScoreToolTipHelper.Score">
+                            <svg class="bi" role="img" aria-label="Score help">
+                                <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                            </svg>
+                            RQSM Score Sheet Calculator
+                        </button>
                         <hr />
                         <div class="row">
                             <div class="container bg-light-subtle m-1">
@@ -728,82 +743,92 @@
                                     </h4>
                                     <hr />
                                     <dl class="row">
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.GWScore)
+                                            <button id="GW-Score-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="GW-Score-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.GWScore"><svg class="bi" role="img" aria-label="GW Score help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.GWScore, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.A)
+                                            <button id="A-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="A-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.AReleaseType"><svg class="bi" role="img" aria-label="A help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.A, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.B1)
+                                            <button id="B1-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="B1-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.B1Susceptibility"><svg class="bi" role="img" aria-label="B1 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.B1, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.B2)
+                                            <button id="B2-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="B2-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.B2PhysicalState"><svg class="bi" role="img" aria-label="B2 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.B2, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.C)
+                                            <button id="C-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="C-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.CContainment"><svg class="bi" role="img" aria-label="C help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.C, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.Description)
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.Description, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.CASNO)
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.CASNO, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.ChemName)
+                                            <button id="ChemName-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="ChemName-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.ChemicalName"><svg class="bi" role="img" aria-label="ChemName help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.ChemName, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.Other)
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.Other, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.D2)
+                                            <button id="D2-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="D2-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.D2ToxVal"><svg class="bi" role="img" aria-label="D2 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.D2, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.D3)
+                                            <button id="D3-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="D3-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.D3Quantity"><svg class="bi" role="img" aria-label="D3 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.D3, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5 ">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.E1)
+                                            <button id="E1-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="E1-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="@GWToolTipHelper.E1Exposure"><svg class="bi" role="img" aria-label="E1 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.E1, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.E2)
+                                            <button id="E2-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="E2-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.E2DistanceToWell"><svg class="bi" role="img" aria-label="E2 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.E2, "Number")
                                         </dd>
                                     </dl>
@@ -1161,66 +1186,66 @@
                                             Event Type
                                             @Html.DisplayFor(m => m.SortBy, "EventSortArrow",
                                             new { up = EventSort.EventType, down = EventSort.EventTypeDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.ActionTaken ? EventSort.ActionTakenDesc : EventSort.ActionTaken)">
-                                        Action Taken
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.ActionTaken, down = EventSort.ActionTakenDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.StartDate ? EventSort.StartDateDesc : EventSort.StartDate)">
-                                        Start Date
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.StartDate, down = EventSort.StartDateDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.DueDate ? EventSort.DueDateDesc : EventSort.DueDate)">
-                                        Due Date
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.DueDate, down = EventSort.DueDateDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.CompletionDate ? EventSort.CompletionDateDesc : EventSort.CompletionDate)">
-                                        Completion Date
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.CompletionDate, down = EventSort.CompletionDateDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.ComplianceOfficer ? EventSort.ComplianceOfficerDesc : EventSort.ComplianceOfficer)">
-                                        Done By
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.ComplianceOfficer, down = EventSort.ComplianceOfficerDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap align-content-end">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.EventAmount ? EventSort.EventAmountDesc : EventSort.EventAmount)">
-                                        Event Amount
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.EventAmount, down = EventSort.EventAmountDesc })
-                                    </a>
-                                </th>
-                                <th scope="col" class="text-nowrap">
-                                    <a asp-fragment="TabPages"
-                                       asp-route-tab="Events"
-                                       asp-route-SortBy="@(Model.SortBy == EventSort.EventContractor ? EventSort.EventContractorDesc : EventSort.EventContractor)">
-                                        Contractor
-                                        @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.EventContractor, down = EventSort.EventContractorDesc })
-                                    </a>
-                                </th>
-                                <th scope="col">Comment</th>
-                                @if (Model.FacilityDetail.Active && (User.IsInRole(UserRoles.FileEditor) || User.IsInRole(UserRoles.ComplianceOfficer)))
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.ActionTaken ? EventSort.ActionTakenDesc : EventSort.ActionTaken)">
+                                            Action Taken
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.ActionTaken, down = EventSort.ActionTakenDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.StartDate ? EventSort.StartDateDesc : EventSort.StartDate)">
+                                            Start Date
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.StartDate, down = EventSort.StartDateDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.DueDate ? EventSort.DueDateDesc : EventSort.DueDate)">
+                                            Due Date
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.DueDate, down = EventSort.DueDateDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.CompletionDate ? EventSort.CompletionDateDesc : EventSort.CompletionDate)">
+                                            Completion Date
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.CompletionDate, down = EventSort.CompletionDateDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.ComplianceOfficer ? EventSort.ComplianceOfficerDesc : EventSort.ComplianceOfficer)">
+                                            Done By
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.ComplianceOfficer, down = EventSort.ComplianceOfficerDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap align-content-end">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.EventAmount ? EventSort.EventAmountDesc : EventSort.EventAmount)">
+                                            Event Amount
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.EventAmount, down = EventSort.EventAmountDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col" class="text-nowrap">
+                                        <a asp-fragment="TabPages"
+                                           asp-route-tab="Events"
+                                           asp-route-SortBy="@(Model.SortBy == EventSort.EventContractor ? EventSort.EventContractorDesc : EventSort.EventContractor)">
+                                            Contractor
+                                            @Html.DisplayFor(m => m.SortBy, "EventSortArrow", new { up = EventSort.EventContractor, down = EventSort.EventContractorDesc })
+                                        </a>
+                                    </th>
+                                    <th scope="col">Comment</th>
+                                    @if (Model.FacilityDetail.Active && (User.IsInRole(UserRoles.FileEditor) || User.IsInRole(UserRoles.ComplianceOfficer)))
                                     {
                                         <th scope="col" class="text-left">Actions</th>
                                     }

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -843,76 +843,175 @@
                                     </h4>
                                     <hr />
                                     <dl class="row">
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.OnsiteScoreValue)
+                                            <button id="OSScore-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="OSScore-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.OSScore">
+                                                <svg class="bi" role="img" aria-label="OSScore help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.OnsiteScoreValue, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.A)
+                                            <button id="A-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="A-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.AAccessToSite">
+                                                <svg class="bi" role="img" aria-label="A help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.A, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.B)
+                                            <button id="B-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="B-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.BReleaseType">
+                                                <svg class="bi" role="img" aria-label="B help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.B, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.C)
+                                            <button id="C-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="C-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.CContainment">
+                                                <svg class="bi" role="img" aria-label="C help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.C, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.Description)
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.Description, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.CASNO)
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.CASNO, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.ChemName1D)
+                                            <button id="ChemName-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="ChemName-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.ChemicalName">
+                                                <svg class="bi" role="img" aria-label="ChemName help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.ChemName1D, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.Other1D)
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.Other1D, "StringOrNone")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.D2)
+                                            <button id="D2-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="D2-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.D2ToxVal">
+                                                <svg class="bi" role="img" aria-label="D2 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.D2, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.D3)
+                                            <button id="D3-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="D3-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.D3Quantity">
+                                                <svg class="bi" role="img" aria-label="D3 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.D3, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.E1)
+                                            <button id="E1-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="E1-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.E1DistanceToResidence">
+                                                <svg class="bi" role="img" aria-label="E1 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.E1, "Number")
                                         </dd>
-                                        <dt class="col-sm-4">
+                                        <dt class="col-sm-6">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.OnsiteScoreDetails.E2)
+                                            <button id="E2-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="E2-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@OnsiteToolTipHelper.E2SensitiveEnvironment">
+                                                <svg class="bi" role="img" aria-label="E2 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
-                                        <dd class="col-sm-8">
+                                        <dd class="col-sm-6">
                                             @Html.DisplayFor(model => model.FacilityDetail.OnsiteScoreDetails.E2, "Number")
                                         </dd>
                                     </dl>

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -1184,12 +1184,34 @@
                         <dl class="row">
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.ISWQS)
+                                <button id="ISWQS-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="ISWQS-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.ISWQS">
+                                    <svg class="bi" role="img" aria-label="ISWQS help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.ISWQS, "BoolYesNo")
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.FundingSource)
+                                <button id="Funding-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="Funding-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.FundingSource">
+                                    <svg class="bi" role="img" aria-label="Funding help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.FundingSource.DisplayName, "StringOrNone")
@@ -1223,6 +1245,17 @@
                             </div>
                             <dt class="col-sm-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.SourceStatus)
+                                <button id="SourceStatus-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="SourceStatus-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.SourceStatus">
+                                    <svg class="bi" role="img" aria-label="SourceStatus help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.SourceStatus.Name, "StringOrNone")
@@ -1235,6 +1268,17 @@
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.SoilStatus)
+                                <button id="SoilStatus-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="SoilStatus-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.SoilStatus">
+                                    <svg class="bi" role="img" aria-label="SoilStatus help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.SoilStatus.Name, "StringOrNone")
@@ -1247,6 +1291,17 @@
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.GroundwaterStatus)
+                                <button id="GroundwaterStatus-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="GroundwaterStatus-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.GroundwaterStatus">
+                                    <svg class="bi" role="img" aria-label="GroundwaterStatus help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.GroundwaterStatus.Name, "StringOrNone")
@@ -1259,6 +1314,17 @@
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.OverallStatus)
+                                <button id="OverallStatus-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="OverallStatus-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.OverallStatus">
+                                    <svg class="bi" role="img" aria-label="OverallStatus help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.OverallStatus.Name, "StringOrNone")
@@ -1271,6 +1337,17 @@
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.GAPSScore)
+                                <button id="GAPSScore-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="GAPSScore-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.GAPSModelScore">
+                                    <svg class="bi" role="img" aria-label="GAPSScore help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.GAPSScore, "NumberOrNone")
@@ -1289,12 +1366,34 @@
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.GAPSAssessment)
+                                <button id="GAPSAssessment-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="GAPSAssessment-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.GAPSAssessment">
+                                    <svg class="bi" role="img" aria-label="GAPSAssessment help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.GAPSAssessment.Name)
                             </dd>
                             <dt class="col-sm-3 pt-3">
                                 @Html.DisplayNameFor(model => model.FacilityDetail.StatusDetails.CostEstimate)
+                                <button id="CostEstimate-help-button"
+                                        type="button"
+                                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                        aria-details="CostEstimate-tooltip-text"
+                                        data-bs-toggle="tooltip"
+                                        data-bs-placement="top"
+                                        title="@StatusToolTipHelper.CostEstimate">
+                                    <svg class="bi" role="img" aria-label="CostEstimate help">
+                                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                    </svg>
+                                </button>
                             </dt>
                             <dd class="col-sm-3 pt-3">
                                 @Html.DisplayFor(model => model.FacilityDetail.StatusDetails.CostEstimate)

--- a/FMS/Pages/Facilities/Details.cshtml
+++ b/FMS/Pages/Facilities/Details.cshtml
@@ -745,35 +745,85 @@
                                     <dl class="row">
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.GWScore)
-                                            <button id="GW-Score-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="GW-Score-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.GWScore"><svg class="bi" role="img" aria-label="GW Score help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="GW-Score-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="GW-Score-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.GWScore">
+                                                <svg class="bi" role="img" aria-label="GW Score help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.GWScore, "Number")
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.A)
-                                            <button id="A-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="A-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.AReleaseType"><svg class="bi" role="img" aria-label="A help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="A-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="A-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.AReleaseType">
+                                                <svg class="bi" role="img" aria-label="A help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.A, "Number")
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.B1)
-                                            <button id="B1-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="B1-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.B1Susceptibility"><svg class="bi" role="img" aria-label="B1 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="B1-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="B1-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.B1Susceptibility">
+                                                <svg class="bi" role="img" aria-label="B1 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.B1, "Number")
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.B2)
-                                            <button id="B2-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="B2-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.B2PhysicalState"><svg class="bi" role="img" aria-label="B2 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="B2-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="B2-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.B2PhysicalState">
+                                                <svg class="bi" role="img" aria-label="B2 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.B2, "Number")
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.C)
-                                            <button id="C-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="C-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.CContainment"><svg class="bi" role="img" aria-label="C help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="C-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="C-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.CContainment">
+                                                <svg class="bi" role="img" aria-label="C help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.C, "Number")
@@ -792,7 +842,17 @@
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.ChemName)
-                                            <button id="ChemName-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="ChemName-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.ChemicalName"><svg class="bi" role="img" aria-label="ChemName help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="ChemName-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="ChemName-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.ChemicalName">
+                                                <svg class="bi" role="img" aria-label="ChemName help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.ChemName, "StringOrNone")
@@ -805,28 +865,69 @@
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.D2)
-                                            <button id="D2-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="D2-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.D2ToxVal"><svg class="bi" role="img" aria-label="D2 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="D2-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="D2-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.D2ToxVal">
+                                                <svg class="bi" role="img" aria-label="D2 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.D2, "Number")
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.D3)
-                                            <button id="D3-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="D3-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.D3Quantity"><svg class="bi" role="img" aria-label="D3 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="D3-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="D3-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.D3Quantity">
+                                                <svg class="bi" role="img" aria-label="D3 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.D3, "Number")
                                         </dd>
                                         <dt class="col-sm-5 ">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.E1)
-                                            <button id="E1-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="E1-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true" title="@GWToolTipHelper.E1Exposure"><svg class="bi" role="img" aria-label="E1 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="E1-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="E1-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    data-bs-html="true"
+                                                    title="@GWToolTipHelper.E1Exposure">
+                                                <svg class="bi" role="img" aria-label="E1 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.E1, "Number")
                                         </dd>
                                         <dt class="col-sm-5">
                                             @Html.DisplayNameFor(model => model.FacilityDetail.GroundwaterScoreDetails.E2)
-                                            <button id="E2-help-button" type="button" style="border: none; padding: 0px; background: none; border-radius: 0px;" aria-details="E2-tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="@GWToolTipHelper.E2DistanceToWell"><svg class="bi" role="img" aria-label="E2 help"><use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use></svg></button>
+                                            <button id="E2-help-button"
+                                                    type="button"
+                                                    style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                                                    aria-details="E2-tooltip-text"
+                                                    data-bs-toggle="tooltip"
+                                                    data-bs-placement="top"
+                                                    title="@GWToolTipHelper.E2DistanceToWell">
+                                                <svg class="bi" role="img" aria-label="E2 help">
+                                                    <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                                                </svg>
+                                            </button>
                                         </dt>
                                         <dd class="col-sm-7">
                                             @Html.DisplayFor(model => model.FacilityDetail.GroundwaterScoreDetails.E2, "Number")

--- a/FMS/Pages/GroundwaterScore/Edit.cshtml
+++ b/FMS/Pages/GroundwaterScore/Edit.cshtml
@@ -1,9 +1,11 @@
 ﻿@page "{id:Guid?}"
+@using FMS.Helpers
 @model FMS.Pages.GroundwaterScore.EditModel
 
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/tooltip.js"></script>
 }
 
 @{
@@ -28,6 +30,17 @@
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.ChemName" class="form-label"></label>
+                <button id="ChemName-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="ChemName-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.ChemicalName">
+                    <svg class="bi" role="img" aria-label="ChemName help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input readonly asp-for="GroundwaterScore.ChemName" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.ChemName" class="text-danger"></span>
             </div>
@@ -40,21 +53,65 @@
         <div class="row mb-3">
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.GWScore" class="form-label"></label>
+                <button id="GW-Score-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="GW-Score-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.GWScore">
+                    <svg class="bi" role="img" aria-label="GW Score help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.GWScore" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.GWScore" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.A" class="form-label"></label>
+                <button id="A-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="A-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.AReleaseType">
+                    <svg class="bi" role="img" aria-label="A help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.A" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.A" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.B1" class="form-label"></label>
+                <button id="B1-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="B1-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.B1Susceptibility">
+                    <svg class="bi" role="img" aria-label="B1 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.B1" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.B1" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.B2" class="form-label"></label>
+                <button id="B2-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="B2-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.B2PhysicalState">
+                    <svg class="bi" role="img" aria-label="B2 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.B2" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.B2" class="text-danger"></span>
             </div>
@@ -62,21 +119,66 @@
         <div class="row mb-3">
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.C" class="form-label"></label>
+                <button id="C-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="C-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.CContainment">
+                    <svg class="bi" role="img" aria-label="C help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.C" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.C" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.D2" class="form-label"></label>
+                <button id="D2-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="D2-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.D2ToxVal">
+                    <svg class="bi" role="img" aria-label="D2 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.D2" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.D2" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.D3" class="form-label"></label>
+                <button id="D3-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="D3-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.D3Quantity">
+                    <svg class="bi" role="img" aria-label="D3 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.D3" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.D3" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="GroundwaterScore.E1" class="form-label"></label>
+                <button id="E1-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="E1-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        data-bs-html="true"
+                        title="@GWToolTipHelper.E1Exposure">
+                    <svg class="bi" role="img" aria-label="E1 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.E1" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.E1" class="text-danger"></span>
             </div>
@@ -84,6 +186,17 @@
         <div class="row mb-3">
             <div class="col-3 mb-3">
                 <label asp-for="GroundwaterScore.E2" class="form-label"></label>
+                <button id="E2-help-button"
+                        type="button"
+                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        aria-details="E2-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@GWToolTipHelper.E2DistanceToWell">
+                    <svg class="bi" role="img" aria-label="E2 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="GroundwaterScore.E2" class="form-control" />
                 <span asp-validation-for="GroundwaterScore.E2" class="text-danger"></span>
             </div>
@@ -96,11 +209,11 @@
         <hr />
         <div class="row mb-3">
             <button id="SubmitButton" type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Update</button>
-            <a asp-page="../Facilities/Details" 
-                asp-route-id="@Model.Facility.Id"
-                asp-route-tab="Score"
-                asp-fragment="TabPages"
-                class="btn btn-outline-secondary col-md-2">
+            <a asp-page="../Facilities/Details"
+               asp-route-id="@Model.Facility.Id"
+               asp-route-tab="Score"
+               asp-fragment="TabPages"
+               class="btn btn-outline-secondary col-md-2">
                 Cancel
             </a>
         </div>

--- a/FMS/Pages/GroundwaterScore/Edit.cshtml
+++ b/FMS/Pages/GroundwaterScore/Edit.cshtml
@@ -32,7 +32,7 @@
                 <label asp-for="GroundwaterScore.ChemName" class="form-label"></label>
                 <button id="ChemName-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="ChemName-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -55,7 +55,7 @@
                 <label asp-for="GroundwaterScore.GWScore" class="form-label"></label>
                 <button id="GW-Score-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="GW-Score-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -71,7 +71,7 @@
                 <label asp-for="GroundwaterScore.A" class="form-label"></label>
                 <button id="A-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="A-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -87,7 +87,7 @@
                 <label asp-for="GroundwaterScore.B1" class="form-label"></label>
                 <button id="B1-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="B1-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -103,7 +103,7 @@
                 <label asp-for="GroundwaterScore.B2" class="form-label"></label>
                 <button id="B2-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="B2-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -121,7 +121,7 @@
                 <label asp-for="GroundwaterScore.C" class="form-label"></label>
                 <button id="C-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="C-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -137,7 +137,7 @@
                 <label asp-for="GroundwaterScore.D2" class="form-label"></label>
                 <button id="D2-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="D2-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -153,7 +153,7 @@
                 <label asp-for="GroundwaterScore.D3" class="form-label"></label>
                 <button id="D3-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="D3-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -169,7 +169,7 @@
                 <label asp-for="GroundwaterScore.E1" class="form-label"></label>
                 <button id="E1-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="E1-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"
@@ -188,7 +188,7 @@
                 <label asp-for="GroundwaterScore.E2" class="form-label"></label>
                 <button id="E2-help-button"
                         type="button"
-                        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
                         aria-details="E2-tooltip-text"
                         data-bs-toggle="tooltip"
                         data-bs-placement="top"

--- a/FMS/Pages/GroundwaterScore/Edit.cshtml.cs
+++ b/FMS/Pages/GroundwaterScore/Edit.cshtml.cs
@@ -6,7 +6,6 @@ using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using FMS.Helpers;
 
 namespace FMS.Pages.GroundwaterScore
 {

--- a/FMS/Pages/GroundwaterScore/Edit.cshtml.cs
+++ b/FMS/Pages/GroundwaterScore/Edit.cshtml.cs
@@ -6,6 +6,7 @@ using FMS.Platform.Extensions;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using FMS.Helpers;
 
 namespace FMS.Pages.GroundwaterScore
 {

--- a/FMS/Pages/OnsiteScore/Edit.cshtml
+++ b/FMS/Pages/OnsiteScore/Edit.cshtml
@@ -1,9 +1,11 @@
 ﻿@page "{id:Guid?}"
+@using FMS.Helpers
 @model FMS.Pages.OnsiteScore.EditModel
 
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/tooltip.js"></script>
 }
 
 @{
@@ -28,6 +30,17 @@
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.ChemName1D" class="form-label"></label>
+                <button id="ChemName-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="ChemName-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.ChemicalName">
+                    <svg class="bi" role="img" aria-label="ChemName help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input readonly asp-for="OnsiteScore.ChemName1D" class="form-control" />
                 <span asp-validation-for="OnsiteScore.ChemName1D" class="text-danger"></span>
             </div>
@@ -40,21 +53,65 @@
         <div class="row mb-3">
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.OnsiteScoreValue" class="form-label"></label>
+                <button id="OSScore-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="OSScore-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.OSScore">
+                    <svg class="bi" role="img" aria-label="OSScore help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.OnsiteScoreValue" class="form-control" />
                 <span asp-validation-for="OnsiteScore.OnsiteScoreValue" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.A" class="form-label"></label>
+                <button id="A-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="A-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.AAccessToSite">
+                    <svg class="bi" role="img" aria-label="A help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.A" class="form-control" />
                 <span asp-validation-for="OnsiteScore.A" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.B" class="form-label"></label>
+                <button id="B-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="B-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.BReleaseType">
+                    <svg class="bi" role="img" aria-label="B help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.B" class="form-control" />
                 <span asp-validation-for="OnsiteScore.B" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.C" class="form-label"></label>
+                <button id="C-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="C-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.CContainment">
+                    <svg class="bi" role="img" aria-label="C help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.C" class="form-control" />
                 <span asp-validation-for="OnsiteScore.C" class="text-danger"></span>
             </div>
@@ -62,21 +119,65 @@
         <div class="row mb-3">
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.D2" class="form-label"></label>
+                <button id="D2-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="D2-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.D2ToxVal">
+                    <svg class="bi" role="img" aria-label="D2 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.D2" class="form-control" />
                 <span asp-validation-for="OnsiteScore.D2" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.D3" class="form-label"></label>
+                <button id="D3-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="D3-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.D3Quantity">
+                    <svg class="bi" role="img" aria-label="D3 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.D3" class="form-control" />
                 <span asp-validation-for="OnsiteScore.D3" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.E1" class="form-label"></label>
+                <button id="E1-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="E1-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.E1DistanceToResidence">
+                    <svg class="bi" role="img" aria-label="E1 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.E1" class="form-control" />
                 <span asp-validation-for="OnsiteScore.E1" class="text-danger"></span>
             </div>
             <div class="col mb-3">
                 <label asp-for="OnsiteScore.E2" class="form-label"></label>
+                <button id="E2-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="E2-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@OnsiteToolTipHelper.E2SensitiveEnvironment">
+                    <svg class="bi" role="img" aria-label="E2 help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="OnsiteScore.E2" class="form-control" />
                 <span asp-validation-for="OnsiteScore.E2" class="text-danger"></span>
             </div>

--- a/FMS/Pages/Score/Edit.cshtml
+++ b/FMS/Pages/Score/Edit.cshtml
@@ -15,6 +15,19 @@
     @ViewData["Title"]
 </h1>
 <hr />
+<button id="Score-help-button"
+        type="button"
+        style="border: none; padding: 5px; background: none; border-radius: 5px;"
+        aria-details="Score-tooltip-text"
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        data-bs-html="true"
+        title="@ScoreToolTipHelper.Score">
+    <svg class="bi" role="img" aria-label="Score help">
+        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+    </svg>
+    RQSM Score Sheet Calculator
+</button>
 <div class="p-3 rounded-3 bg-light-subtle">
     <form method="post">
         <div asp-validation-summary="ModelOnly" class="alert alert-danger" role="alert"></div>
@@ -41,19 +54,6 @@
             </div>
         </div>
         <hr />
-        <button id="Score-help-button"
-                type="button"
-                style="border: none; padding: 5px; background: none; border-radius: 5px;"
-                aria-details="Score-tooltip-text"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-                data-bs-html="true"
-                title="@ScoreToolTipHelper.Score">
-            <svg class="bi" role="img" aria-label="Score help">
-                <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
-            </svg>
-            RQSM Score Sheet Calculator
-        </button>
         <div class="row mb-3">
             <button id="SubmitButton" type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Update</button>
             <a asp-page="../Facilities/Details"

--- a/FMS/Pages/Score/Edit.cshtml
+++ b/FMS/Pages/Score/Edit.cshtml
@@ -1,9 +1,11 @@
 ﻿@page "{id:Guid?}"
+@using FMS.Helpers
 @model FMS.Pages.Score.EditModel
 
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/tooltip.js"></script>
 }
 
 @{
@@ -39,13 +41,26 @@
             </div>
         </div>
         <hr />
+        <button id="Score-help-button"
+                type="button"
+                style="border: none; padding: 5px; background: none; border-radius: 5px;"
+                aria-details="Score-tooltip-text"
+                data-bs-toggle="tooltip"
+                data-bs-placement="top"
+                data-bs-html="true"
+                title="@ScoreToolTipHelper.Score">
+            <svg class="bi" role="img" aria-label="Score help">
+                <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+            </svg>
+            RQSM Score Sheet Calculator
+        </button>
         <div class="row mb-3">
             <button id="SubmitButton" type="submit" class="btn btn-primary col-sm-4 col-md-3 mb-3 mb-sm-0">Update</button>
             <a asp-page="../Facilities/Details"
                asp-fragment="TabPages"
-                asp-route-id="@Model.Facility.Id"
-                asp-route-tab="Score"
-                class="btn btn-outline-secondary col-md-2">
+               asp-route-id="@Model.Facility.Id"
+               asp-route-tab="Score"
+               class="btn btn-outline-secondary col-md-2">
                 Cancel
             </a>
         </div>

--- a/FMS/Pages/Status/Edit.cshtml
+++ b/FMS/Pages/Status/Edit.cshtml
@@ -1,9 +1,11 @@
 ﻿@page "{id:Guid?}"
+@using FMS.Helpers
 @model FMS.Pages.Status.EditModel
 
 @section Scripts
 {
     <partial name="_ValidationScriptsPartial" />
+    <script src="~/js/tooltip.js"></script>
 }
 
 @{
@@ -22,6 +24,17 @@
         <div class="row mb-3 align-items-center">
             <div class="col mb-4">
                 <label asp-for="EditStatus.FundingSourceId" class="form-label"></label>
+                <button id="Funding-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="Funding-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.FundingSource">
+                    <svg class="bi" role="img" aria-label="Funding help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <select asp-for="EditStatus.FundingSourceId" asp-items="Model.FundingSources" class="form-select">
                     <option value=""></option>
                 </select>
@@ -30,6 +43,17 @@
             <div class="col-md-2">
                 <input asp-for="EditStatus.ISWQS" class="form-check-input" />
                 <label asp-for="EditStatus.ISWQS" class="form-check-label"></label>
+                <button id="ISWQS-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="ISWQS-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.ISWQS">
+                    <svg class="bi" role="img" aria-label="ISWQS help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <span asp-validation-for="EditStatus.ISWQS" class="text-danger"></span>
             </div>
             <div class="col-md-2">
@@ -61,6 +85,17 @@
         <div class="row mb-3">
             <div class="col-md-3">
                 <label asp-for="EditStatus.SourceStatusId" class="form-label"></label>
+                <button id="SourceStatus-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="SourceStatus-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.SourceStatus">
+                    <svg class="bi" role="img" aria-label="SourceStatus help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <select asp-for="EditStatus.SourceStatusId" asp-items="Model.SourceStatuses" class="form-select">
                     <option value=""></option>
                 </select>
@@ -75,6 +110,17 @@
             </div>
             <div class="col-md-3">
                 <label asp-for="EditStatus.SoilStatusId" class="form-label"></label>
+                <button id="SoilStatus-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="SoilStatus-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.SoilStatus">
+                    <svg class="bi" role="img" aria-label="SoilStatus help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <select asp-for="EditStatus.SoilStatusId" asp-items="Model.SoilStatuses" class="form-select">
                     <option value=""></option>
                 </select>
@@ -91,6 +137,17 @@
         <div class="row mb-3">
             <div class="col-md-3">
                 <label asp-for="EditStatus.GroundwaterStatusId" class="form-label"></label>
+                <button id="GroundwaterStatus-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="GroundwaterStatus-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.GroundwaterStatus">
+                    <svg class="bi" role="img" aria-label="GroundwaterStatus help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <select asp-for="EditStatus.GroundwaterStatusId" asp-items="Model.GroundwaterStatuses" class="form-select">
                     <option value=""></option>
                 </select>
@@ -105,6 +162,17 @@
             </div>
             <div class="col-md-3">
                 <label asp-for="EditStatus.OverallStatusId" class="form-label"></label>
+                <button id="OverallStatus-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="OverallStatus-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.OverallStatus">
+                    <svg class="bi" role="img" aria-label="OverallStatus help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <select asp-for="EditStatus.OverallStatusId" asp-items="Model.OverallStatuses" class="form-select">
                     <option value=""></option>
                 </select>
@@ -121,6 +189,17 @@
         <div class="row mb-3">
             <div class="col-md-3">
                 <label asp-for="EditStatus.GAPSScore" class="form-label"></label>
+                <button id="GAPSScore-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="GAPSScore-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.GAPSModelScore">
+                    <svg class="bi" role="img" aria-label="GAPSScore help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="EditStatus.GAPSScore" class="form-control" />
                 <span asp-validation-for="EditStatus.GAPSScore" class="text-danger"></span>
             </div>
@@ -136,6 +215,17 @@
             </div>
             <div class="col mb-3">
                 <label asp-for="EditStatus.GAPSAssessmentId" class="form-label"></label>
+                <button id="GAPSAssessment-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="GAPSAssessment-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.GAPSAssessment">
+                    <svg class="bi" role="img" aria-label="GAPSAssessment help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <select asp-for="EditStatus.GAPSAssessmentId" asp-items="Model.GAPSAssessments" class="form-select">
                     <option value=""></option>
                 </select>
@@ -145,6 +235,17 @@
         <div class="row mb-3">
             <div class="col-md-3">
                 <label asp-for="EditStatus.CostEstimate" class="form-label"></label>
+                <button id="CostEstimate-help-button"
+                        type="button"
+                        style="border: none; padding: 0px; background: none; border-radius: 0px;"
+                        aria-details="CostEstimate-tooltip-text"
+                        data-bs-toggle="tooltip"
+                        data-bs-placement="top"
+                        title="@StatusToolTipHelper.CostEstimate">
+                    <svg class="bi" role="img" aria-label="CostEstimate help">
+                        <use href="@Url.Content("~/images/app-icons.svg")#app-icon-question-circle"></use>
+                    </svg>
+                </button>
                 <input asp-for="EditStatus.CostEstimate" class="form-control" />
                 <span asp-validation-for="EditStatus.CostEstimate" class="text-danger"></span>
             </div>

--- a/FMS/wwwroot/js/tooltip.js
+++ b/FMS/wwwroot/js/tooltip.js
@@ -1,0 +1,7 @@
+﻿
+(() => {
+    'use strict'
+
+    const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]')
+    const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl))
+})()


### PR DESCRIPTION
Introduce informative tooltips to the RQSM Score and Groundwater Score sections on the Facility Details and Score Edit pages. This enhancement guides users by providing definitions, explanations, and links to relevant documentation directly within the UI, improving clarity and usability.